### PR TITLE
Refactor Kilter board sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # macOS
 .DS_Store
+**/.DS_Store
 
 # Xcode user-specific stuff (never commit)
 *.xcuserstate
@@ -76,4 +77,3 @@ playground.xcworkspace
 *.tmp
 *.lock
 *.log
-

--- a/ClimbingProgram/app/BoardCredentialsSettingsView.swift
+++ b/ClimbingProgram/app/BoardCredentialsSettingsView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct BoardCredentialsSettingsView: View {
-    @State private var activeBoard: TB2Client.Board?
+    @State private var activeBoard: BoardConnection?
     @State private var credsUsername = ""
     @State private var credsPassword = ""
     @State private var boardCredentialsVersion = 0
@@ -48,7 +48,7 @@ struct BoardCredentialsSettingsView: View {
         .navigationBarTitleDisplayMode(.inline)
         .sheet(item: $activeBoard) { board in
             TB2CredentialsSheet(
-                header: board == .kilter ? "Kilter login details" : "TB2 login details",
+                header: board.credentialsHeader,
                 username: $credsUsername,
                 password: $credsPassword,
                 onSave: {
@@ -57,13 +57,9 @@ struct BoardCredentialsSettingsView: View {
 
                     do {
                         if username.isEmpty && password.isEmpty {
-                            try CredentialsStore.deleteBoardCredentials(for: board)
+                            try deleteCredentials(for: board)
                         } else {
-                            try CredentialsStore.saveBoardCredentials(
-                                for: board,
-                                username: username,
-                                password: password
-                            )
+                            try saveCredentials(for: board, username: username, password: password)
                         }
                         boardCredentialsVersion += 1
                         activeBoard = nil
@@ -86,8 +82,8 @@ struct BoardCredentialsSettingsView: View {
         }
     }
 
-    private func openCredentialsEditor(for board: TB2Client.Board) {
-        if let creds = CredentialsStore.loadBoardCredentials(for: board) {
+    private func openCredentialsEditor(for board: BoardConnection) {
+        if let creds = loadCredentials(for: board) {
             credsUsername = creds.username
             credsPassword = creds.password
         } else {
@@ -97,9 +93,9 @@ struct BoardCredentialsSettingsView: View {
         activeBoard = board
     }
 
-    private func clearBoardCredentials(for board: TB2Client.Board) {
+    private func clearBoardCredentials(for board: BoardConnection) {
         do {
-            try CredentialsStore.deleteBoardCredentials(for: board)
+            try deleteCredentials(for: board)
             boardCredentialsVersion += 1
             if activeBoard == board {
                 credsUsername = ""
@@ -110,15 +106,44 @@ struct BoardCredentialsSettingsView: View {
         }
     }
 
-    private func hasBoardCredentials(for board: TB2Client.Board) -> Bool {
-        CredentialsStore.loadBoardCredentials(for: board) != nil
+    private func hasBoardCredentials(for board: BoardConnection) -> Bool {
+        loadCredentials(for: board) != nil
     }
 
-    private func boardCredentialStatus(for board: TB2Client.Board) -> String {
+    private func boardCredentialStatus(for board: BoardConnection) -> String {
         hasBoardCredentials(for: board) ? "Configured" : "Not set"
     }
 
-    private func boardDisplayName(_ board: TB2Client.Board) -> String {
-        board == .kilter ? "Kilter" : "Tension Board"
+    private func boardDisplayName(_ board: BoardConnection) -> String {
+        board.displayName
+    }
+
+    private func loadCredentials(for board: BoardConnection) -> TB2Credentials? {
+        switch board {
+        case .tension:
+            return CredentialsStore.loadBoardCredentials(for: .tension)
+        case .kilter:
+            return CredentialsStore.loadKilterCredentials().map {
+                TB2Credentials(username: $0.username, password: $0.password)
+            }
+        }
+    }
+
+    private func saveCredentials(for board: BoardConnection, username: String, password: String) throws {
+        switch board {
+        case .tension:
+            try CredentialsStore.saveBoardCredentials(for: .tension, username: username, password: password)
+        case .kilter:
+            try CredentialsStore.saveKilterCredentials(username: username, password: password)
+        }
+    }
+
+    private func deleteCredentials(for board: BoardConnection) throws {
+        switch board {
+        case .tension:
+            try CredentialsStore.deleteBoardCredentials(for: .tension)
+        case .kilter:
+            try CredentialsStore.deleteKilterCredentials()
+        }
     }
 }

--- a/ClimbingProgram/data/models/ClimbModels.swift
+++ b/ClimbingProgram/data/models/ClimbModels.swift
@@ -28,6 +28,8 @@ final class ClimbEntry {
     var notes: String?
     var dateLogged: Date
     var tb2ClimbUUID: String?
+    var kilterLogUuid: String?
+    var kilterClimbUuid: String?
     
     //support multiple media files per climb
         @Relationship(deleteRule: .cascade, inverse: \ClimbMedia.climb)
@@ -48,7 +50,9 @@ final class ClimbEntry {
         gym: String,
         notes: String? = nil,
         dateLogged: Date = Date(),
-        tb2ClimbUUID: String? = nil
+        tb2ClimbUUID: String? = nil,
+        kilterLogUuid: String? = nil,
+        kilterClimbUuid: String? = nil
     ) {
         self.id = id
         self.climbType = climbType
@@ -65,6 +69,8 @@ final class ClimbEntry {
         self.notes = notes
         self.dateLogged = dateLogged
         self.tb2ClimbUUID = tb2ClimbUUID
+        self.kilterLogUuid = kilterLogUuid
+        self.kilterClimbUuid = kilterClimbUuid
     }
 }
 

--- a/ClimbingProgram/features/climb/BoardConnection.swift
+++ b/ClimbingProgram/features/climb/BoardConnection.swift
@@ -1,0 +1,34 @@
+//
+//  BoardConnection.swift
+//  Klettrack
+//
+
+import Foundation
+
+enum BoardConnection: String, Identifiable {
+    case tension
+    case kilter
+
+    var id: Self { self }
+
+    var credentialsHeader: String {
+        switch self {
+        case .tension: return "TB2 login details"
+        case .kilter: return "Kilter login details"
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .tension: return "Tension Board"
+        case .kilter: return "Kilter"
+        }
+    }
+
+    var missingCredentialsMessage: String {
+        switch self {
+        case .tension: return "Please enter your Tension board credentials."
+        case .kilter: return "Please enter your Kilter board credentials."
+        }
+    }
+}

--- a/ClimbingProgram/features/climb/BoardSyncShared.swift
+++ b/ClimbingProgram/features/climb/BoardSyncShared.swift
@@ -1,0 +1,159 @@
+//
+//  BoardSyncShared.swift
+//  Klettrack
+//
+
+import CryptoKit
+import Foundation
+
+enum BoardGradeMapper {
+    static let mappingCSV = """
+    difficulty,grade_label
+    1,1a/V0
+    2,1b/V0
+    3,1c/V0
+    4,2a/V0
+    5,2b/V0
+    6,2c/V0
+    7,3a/V0
+    8,3b/V0
+    9,3c/V0
+    10,4a/V0
+    11,4b/V0
+    12,4c/V0
+    13,5a/V1
+    14,5b/V1
+    15,5c/V2
+    16,6a/V3
+    17,6a+/V3
+    18,6b/V4
+    19,6b+/V4
+    20,6c/V5
+    21,6c+/V5
+    22,7a/V6
+    23,7a+/V7
+    24,7b/V8
+    25,7b+/V8
+    26,7c/V9
+    27,7c+/V10
+    28,8a/V11
+    29,8a+/V12
+    30,8b/V13
+    31,8b+/V14
+    32,8c/V15
+    33,8c+/V16
+    34,9a/V17
+    35,9a+/V18
+    36,9b/V19
+    37,9b+/V20
+    38,9c/V21
+    39,9c+/V22
+    """
+
+    static let diffToGrade: [Int: String] = {
+        var out: [Int: String] = [:]
+        for line in mappingCSV.split(separator: "\n") {
+            let t = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            if t.isEmpty || t.hasPrefix("#") || t.lowercased().hasPrefix("difficulty") { continue }
+            let parts = t.split(separator: ",", maxSplits: 1).map { String($0).trimmingCharacters(in: .whitespaces) }
+            guard parts.count >= 2, let n = Int(parts[0]) else { continue }
+            out[n] = leftPart(of: parts[1])
+        }
+        return out
+    }()
+
+    static func leftPart(of label: String) -> String {
+        let first = label.split(separator: "/", maxSplits: 1, omittingEmptySubsequences: false).first ?? Substring("")
+        let leftDot = first.split(separator: "·", maxSplits: 1, omittingEmptySubsequences: false).first ?? Substring("")
+        return String(leftDot).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    static func grade(of number: Any?) -> String? {
+        guard let n = number else { return nil }
+        let value: Double?
+        if let i = n as? Int {
+            value = Double(i)
+        } else if let d = n as? Double {
+            value = d
+        } else if let s = n as? String {
+            value = Double(s)
+        } else {
+            value = nil
+        }
+        guard let v = value else { return nil }
+        let key = Int(v.rounded())
+        return diffToGrade[key]
+    }
+}
+
+enum BoardDateParser {
+    static let isoFull: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    static let isoBasic: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
+
+    private static func makeFormatter(_ fmt: String, tzUTC: Bool = true) -> DateFormatter {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = tzUTC ? TimeZone(secondsFromGMT: 0) : TimeZone.current
+        f.dateFormat = fmt
+        return f
+    }
+
+    static let f1 = makeFormatter("yyyy-MM-dd HH:mm:ss.SSSSSSXXXXX")
+    static let f2 = makeFormatter("yyyy-MM-dd HH:mm:ss.SSSSSSxxxx")
+    static let f3 = makeFormatter("yyyy-MM-dd HH:mm:ss.SSSSSS")
+    static let f4 = makeFormatter("yyyy-MM-dd HH:mm:ssXXXXX")
+    static let f5 = makeFormatter("yyyy-MM-dd HH:mm:ssxxxx")
+    static let f6 = makeFormatter("yyyy-MM-dd HH:mm:ss")
+    static let f7 = makeFormatter("yyyy-MM-dd")
+    static let f8 = makeFormatter("yyyy-MM-dd'T'HH:mm:ss.SSSSSSXXXXX")
+    static let f9 = makeFormatter("yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX")
+    static let f10 = makeFormatter("yyyy-MM-dd'T'HH:mm:ssXXXXX")
+
+    static func parse(_ s: String?) -> Date? {
+        guard var s = s?.trimmingCharacters(in: .whitespacesAndNewlines), !s.isEmpty else { return nil }
+
+        if CharacterSet.decimalDigits.isSuperset(of: CharacterSet(charactersIn: s)),
+           let v = Double(s) {
+            if s.count >= 13 { return Date(timeIntervalSince1970: v / 1000.0) }
+            if s.count >= 10 { return Date(timeIntervalSince1970: v) }
+        }
+
+        if let d = isoFull.date(from: s) { return d }
+        if let d = isoBasic.date(from: s) { return d }
+
+        for f in [f1, f2, f3, f4, f5, f6, f7, f8, f9, f10] {
+            if let d = f.date(from: s) { return d }
+        }
+
+        if s.hasSuffix(" UTC") {
+            s.removeLast(4)
+            for f in [f3, f6, f7] {
+                if let d = f.date(from: s) { return d }
+            }
+        }
+        return nil
+    }
+}
+
+enum BoardSyncIdentity {
+    static func deterministicUUID(from string: String) -> UUID {
+        let hash = SHA256.hash(data: Data(string.utf8))
+        let bytes = Array(hash.prefix(16))
+        let uuid = uuid_t(
+            bytes[0], bytes[1], bytes[2], bytes[3],
+            bytes[4], bytes[5], bytes[6], bytes[7],
+            bytes[8], bytes[9], bytes[10], bytes[11],
+            bytes[12], bytes[13], bytes[14], bytes[15]
+        )
+        return UUID(uuid: uuid)
+    }
+}

--- a/ClimbingProgram/features/climb/ClimbView.swift
+++ b/ClimbingProgram/features/climb/ClimbView.swift
@@ -57,8 +57,8 @@ struct ClimbView: View {
     @State private var isSyncing = false
     @State private var syncMessage: String? = nil
     @State private var showingBoardPicker = false
-    @State private var activeBoard: TB2Client.Board? = nil
-    @State private var pendingSyncBoard: TB2Client.Board? = nil
+    @State private var activeBoard: BoardConnection? = nil
+    @State private var pendingSyncBoard: BoardConnection? = nil
     
     // Shared undo components
     @State private var undoSnackbar = UndoSnackbarController()
@@ -255,35 +255,38 @@ struct ClimbView: View {
         // Credentials prompt sheet
         .sheet(item: $activeBoard) { board in
             TB2CredentialsSheet(
-                header: (board == .kilter) ? "Kilter login details" : "TB2 login details",
+                header: board.credentialsHeader,
                 username: $credsUsername,
                 password: $credsPassword,
                 onSave: {
                     let username = credsUsername.trimmingCharacters(in: .whitespacesAndNewlines)
                     let password = credsPassword
+                    let syncAfterSave = pendingSyncBoard
                     
                     do {
                         if username.isEmpty && password.isEmpty {
                             // Both empty → treat as "remove credentials"
-                            try CredentialsStore.deleteBoardCredentials(for: board)
+                            try deleteCredentials(for: board)
                         } else {
                             // Non-empty → save/update credentials
-                            try CredentialsStore.saveBoardCredentials(
-                                for: board,
-                                username: username,
-                                password: password
-                            )
+                            try saveCredentials(for: board, username: username, password: password)
                         }
                         
                         isEditingCredentials = false
+                        pendingSyncBoard = nil
                         activeBoard = nil
+                        if let syncAfterSave {
+                            Task { await runSyncIfPossible(board: syncAfterSave) }
+                        }
                     } catch {
                         isEditingCredentials = false
+                        pendingSyncBoard = nil
                         activeBoard = nil
                     }
                 },
                 onCancel: {
                     isEditingCredentials = false
+                    pendingSyncBoard = nil
                     activeBoard = nil
                 }
             )
@@ -561,8 +564,8 @@ struct ClimbView: View {
         }
     }
     
-    private func openCredentialsEditor(for board: TB2Client.Board) {
-        if let creds = CredentialsStore.loadBoardCredentials(for: board) {
+    private func openCredentialsEditor(for board: BoardConnection) {
+        if let creds = loadCredentials(for: board) {
             credsUsername = creds.username
             credsPassword = creds.password
         } else {
@@ -575,8 +578,8 @@ struct ClimbView: View {
     }
 
 
-    private func startSync(board: TB2Client.Board) {
-        if let _ = CredentialsStore.loadBoardCredentials(for: board) {
+    private func startSync(board: BoardConnection) {
+        if loadCredentials(for: board) != nil {
             Task { await runSyncIfPossible(board: board) }
         } else {
             // Missing creds → open sheet for this board, then sync after saving
@@ -589,15 +592,27 @@ struct ClimbView: View {
     }
 
     
-    private func runSyncIfPossible(board: TB2Client.Board) async {
-        guard let creds = CredentialsStore.loadBoardCredentials(for: board) else {
-            syncMessage = "Please enter your \(board == .kilter ? "Kilter" : "Tension") board credentials."
+    private func runSyncIfPossible(board: BoardConnection) async {
+        guard let creds = loadCredentials(for: board) else {
+            syncMessage = board.missingCredentialsMessage
             return
         }
         isSyncing = true
         defer { isSyncing = false }
         do {
-            try await TB2SyncManager.sync(using: creds, board: board, into: modelContext)
+            switch board {
+            case .tension:
+                try await TB2SyncManager.sync(
+                    using: TB2Credentials(username: creds.username, password: creds.password),
+                    board: .tension,
+                    into: modelContext
+                )
+            case .kilter:
+                try await KilterSyncManager.sync(
+                    using: KilterCredentials(username: creds.username, password: creds.password),
+                    into: modelContext
+                )
+            }
             syncMessage = "Sync completed."
 
             // Count successful syncs (any board). After 3+, arm a one-time review request.
@@ -607,6 +622,35 @@ struct ClimbView: View {
             }
         } catch {
             syncMessage = "Sync failed: \(error.localizedDescription)"
+        }
+    }
+
+    private func loadCredentials(for board: BoardConnection) -> TB2Credentials? {
+        switch board {
+        case .tension:
+            return CredentialsStore.loadBoardCredentials(for: .tension)
+        case .kilter:
+            return CredentialsStore.loadKilterCredentials().map {
+                TB2Credentials(username: $0.username, password: $0.password)
+            }
+        }
+    }
+
+    private func saveCredentials(for board: BoardConnection, username: String, password: String) throws {
+        switch board {
+        case .tension:
+            try CredentialsStore.saveBoardCredentials(for: .tension, username: username, password: password)
+        case .kilter:
+            try CredentialsStore.saveKilterCredentials(username: username, password: password)
+        }
+    }
+
+    private func deleteCredentials(for board: BoardConnection) throws {
+        switch board {
+        case .tension:
+            try CredentialsStore.deleteBoardCredentials(for: .tension)
+        case .kilter:
+            try CredentialsStore.deleteKilterCredentials()
         }
     }
 

--- a/ClimbingProgram/features/climb/CredentialsStore.swift
+++ b/ClimbingProgram/features/climb/CredentialsStore.swift
@@ -12,9 +12,15 @@ struct TB2Credentials: Codable {
     let password: String
 }
 
+struct KilterCredentials: Codable {
+    let username: String
+    let password: String
+}
+
 enum CredentialsStore {
     private static let service = "ClimbingProgram.TB2"
     private static let account = "credentials"
+    private static let kilterAccount = "credentials.kilter.grips"
     
     // MARK: - Legacy single-credential helpers (kept for compatibility; used for Tension by older code)
     static func loadTB2Credentials() -> TB2Credentials? {
@@ -34,7 +40,6 @@ enum CredentialsStore {
     private static func account(for board: TB2Client.Board) -> String {
         switch board {
         case .tension: return "\(account).tension"
-        case .kilter:  return "\(account).kilter"
         }
     }
 
@@ -89,5 +94,58 @@ enum CredentialsStore {
             throw NSError(domain: NSOSStatusErrorDomain, code: Int(status), userInfo: [NSLocalizedDescriptionKey: "Keychain delete failed (\(status))"])
         }
     }
-}
 
+    // MARK: - Kilter credentials
+
+    static func loadKilterCredentials() -> KilterCredentials? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: kilterAccount,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status == errSecSuccess, let data = item as? Data else { return nil }
+        return try? JSONDecoder().decode(KilterCredentials.self, from: data)
+    }
+
+    static func saveKilterCredentials(username: String, password: String) throws {
+        let creds = KilterCredentials(username: username, password: password)
+        let data = try JSONEncoder().encode(creds)
+
+        let baseQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: kilterAccount
+        ]
+        let attributes: [String: Any] = [kSecValueData as String: data]
+
+        let status = SecItemUpdate(baseQuery as CFDictionary, attributes as CFDictionary)
+        if status == errSecSuccess { return }
+
+        if status == errSecItemNotFound {
+            var addQuery = baseQuery
+            addQuery[kSecValueData as String] = data
+            let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+            guard addStatus == errSecSuccess else {
+                throw NSError(domain: NSOSStatusErrorDomain, code: Int(addStatus), userInfo: [NSLocalizedDescriptionKey: "Keychain add failed (\(addStatus))"])
+            }
+        } else {
+            throw NSError(domain: NSOSStatusErrorDomain, code: Int(status), userInfo: [NSLocalizedDescriptionKey: "Keychain update failed (\(status))"])
+        }
+    }
+
+    static func deleteKilterCredentials() throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: kilterAccount
+        ]
+        let status = SecItemDelete(query as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw NSError(domain: NSOSStatusErrorDomain, code: Int(status), userInfo: [NSLocalizedDescriptionKey: "Keychain delete failed (\(status))"])
+        }
+    }
+}

--- a/ClimbingProgram/features/climb/KilterClient.swift
+++ b/ClimbingProgram/features/climb/KilterClient.swift
@@ -1,0 +1,149 @@
+//
+//  KilterClient.swift
+//  Klettrack
+//
+
+import Foundation
+
+struct KilterTokenResponse: Decodable, Sendable {
+    let accessToken: String
+    let expiresIn: Int?
+    let refreshToken: String?
+    let tokenType: String?
+
+    enum CodingKeys: String, CodingKey {
+        case accessToken = "access_token"
+        case expiresIn = "expires_in"
+        case refreshToken = "refresh_token"
+        case tokenType = "token_type"
+    }
+}
+
+struct KilterLog: Decodable, Sendable {
+    let logUuid: String
+    let climbUuid: String
+    let userUuid: String?
+    let gymUuid: String?
+    let wallUuid: String?
+    let productLayoutUuid: String?
+    let angle: Int?
+    let flashed: Bool
+    let topped: Bool
+    let attempts: Int
+    let createdAt: String
+    let climbName: String?
+    let currentDifficultyId: Int?
+    let climbRating: KilterClimbRating?
+}
+
+struct KilterClimbRating: Decodable, Sendable {
+    let climbRatingUuid: String?
+    let userUuid: String?
+    let gymUuid: String?
+    let wallUuid: String?
+    let productLayoutUuid: String?
+    let climbUuid: String?
+    let angle: Int?
+    let rating: Int?
+    let weight: Double?
+    let difficultyGradeId: Int?
+    let comment: String?
+    let createdAt: String?
+    let status: String?
+}
+
+struct KilterClient: Sendable {
+    typealias DataLoader = @Sendable (URLRequest) async throws -> (Data, URLResponse)
+
+    private let tokenURL: URL
+    private let apiBaseURL: URL
+    private let dataLoader: DataLoader
+
+    init(
+        tokenURL: URL = URL(string: "https://idp.kiltergrips.com/realms/kilter/protocol/openid-connect/token")!,
+        apiBaseURL: URL = URL(string: "https://portal.kiltergrips.com/api")!,
+        dataLoader: @escaping DataLoader = { request in
+            try await URLSession.shared.data(for: request)
+        }
+    ) {
+        self.tokenURL = tokenURL
+        self.apiBaseURL = apiBaseURL
+        self.dataLoader = dataLoader
+    }
+
+    func login(username: String, password: String) async throws -> KilterTokenResponse {
+        var request = URLRequest(url: tokenURL)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.httpBody = Self.formURLEncoded([
+            ("grant_type", "password"),
+            ("client_id", "kilter"),
+            ("scope", "openid offline_access profile email"),
+            ("username", username),
+            ("password", password)
+        ]).data(using: .utf8)
+
+        let (data, response) = try await dataLoader(request)
+        guard let http = response as? HTTPURLResponse else {
+            throw URLError(.badServerResponse)
+        }
+
+        if http.statusCode == 400 || http.statusCode == 401 {
+            throw NSError(domain: "Kilter", code: http.statusCode, userInfo: [
+                NSLocalizedDescriptionKey: "Invalid Kilter username or password."
+            ])
+        }
+
+        guard (200..<300).contains(http.statusCode) else {
+            throw NSError(domain: "Kilter", code: http.statusCode, userInfo: [
+                NSLocalizedDescriptionKey: "Kilter login failed (\(http.statusCode))."
+            ])
+        }
+
+        return try JSONDecoder().decode(KilterTokenResponse.self, from: data)
+    }
+
+    func fetchLogs(accessToken: String) async throws -> [KilterLog] {
+        let logsURL = apiBaseURL.appending(path: "logs/")
+        var request = URLRequest(url: logsURL)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let (data, response) = try await dataLoader(request)
+        guard let http = response as? HTTPURLResponse else {
+            throw URLError(.badServerResponse)
+        }
+
+        if http.statusCode == 401 {
+            throw NSError(domain: "Kilter", code: 401, userInfo: [
+                NSLocalizedDescriptionKey: "Kilter token expired or unauthorized."
+            ])
+        }
+
+        guard (200..<300).contains(http.statusCode) else {
+            throw NSError(domain: "Kilter", code: http.statusCode, userInfo: [
+                NSLocalizedDescriptionKey: "Kilter logs sync failed (\(http.statusCode))."
+            ])
+        }
+
+        return try JSONDecoder().decode([KilterLog].self, from: data)
+    }
+
+    static func formURLEncoded(_ pairs: [(String, String)]) -> String {
+        pairs
+            .map { key, value in
+                "\(formEncode(key))=\(formEncode(value))"
+            }
+            .joined(separator: "&")
+    }
+
+    private static func formEncode(_ value: String) -> String {
+        var allowed = CharacterSet.alphanumerics
+        allowed.insert(charactersIn: "-._*")
+        return value
+            .addingPercentEncoding(withAllowedCharacters: allowed)?
+            .replacing("%20", with: "+") ?? value
+    }
+}

--- a/ClimbingProgram/features/climb/KilterSyncManager.swift
+++ b/ClimbingProgram/features/climb/KilterSyncManager.swift
@@ -1,0 +1,170 @@
+//
+//  KilterSyncManager.swift
+//  Klettrack
+//
+
+import Foundation
+import SwiftData
+
+enum KilterSyncManager {
+    struct Row: Sendable {
+        let logUuid: String
+        let climbUuid: String
+        let day: Date
+        let topped: Bool
+        let angle: Int?
+        let attempts: Int
+        let flashed: Bool
+        let climbName: String?
+        let grade: String?
+        let feelsLikeGrade: String?
+    }
+
+    static func sync(using creds: KilterCredentials, into context: ModelContext, client: KilterClient = KilterClient()) async throws {
+        var token = try await client.login(username: creds.username, password: creds.password)
+        let logs: [KilterLog]
+        do {
+            logs = try await client.fetchLogs(accessToken: token.accessToken)
+        } catch let error as NSError where error.domain == "Kilter" && error.code == 401 {
+            token = try await client.login(username: creds.username, password: creds.password)
+            logs = try await client.fetchLogs(accessToken: token.accessToken)
+        }
+
+        let rows = logs.compactMap { log -> Row? in
+            guard let date = BoardDateParser.parse(log.createdAt) else { return nil }
+            return Row(
+                logUuid: log.logUuid,
+                climbUuid: log.climbUuid,
+                day: date,
+                topped: log.topped,
+                angle: log.angle,
+                attempts: log.attempts,
+                flashed: log.flashed,
+                climbName: log.climbName,
+                grade: BoardGradeMapper.grade(of: log.currentDifficultyId),
+                feelsLikeGrade: BoardGradeMapper.grade(of: log.climbRating?.difficultyGradeId)
+            )
+        }
+        .sorted { $0.day < $1.day }
+
+        try await applyRows(rows, into: context)
+    }
+
+    @MainActor
+    internal static func applyRows(_ rows: [Row], into context: ModelContext) throws {
+        for row in rows {
+            let existing = findExistingEntry(for: row, in: context)
+            let previously = wasPreviouslyClimbed(
+                in: context,
+                kilterClimbUuid: row.climbUuid,
+                angleDegrees: row.angle,
+                before: row.day,
+                excludingLogUuid: existing?.kilterLogUuid ?? row.logUuid
+            )
+
+            if let existing {
+                update(existing, with: row, previouslyClimbed: previously)
+            } else {
+                let entry = ClimbEntry(
+                    id: stableID(logUuid: row.logUuid),
+                    climbType: .boulder,
+                    grade: row.grade ?? "",
+                    feelsLikeGrade: row.feelsLikeGrade,
+                    angleDegrees: row.angle,
+                    style: "Kilter board",
+                    attempts: String(row.attempts),
+                    isWorkInProgress: !row.topped,
+                    isPreviouslyClimbed: previously,
+                    holdColor: nil,
+                    gym: row.climbName ?? "",
+                    notes: row.climbName,
+                    dateLogged: row.day,
+                    kilterLogUuid: row.logUuid,
+                    kilterClimbUuid: row.climbUuid
+                )
+                context.insert(entry)
+            }
+        }
+        try context.save()
+    }
+
+    @MainActor
+    internal static func wasPreviouslyClimbed(
+        in context: ModelContext,
+        kilterClimbUuid: String,
+        angleDegrees: Int?,
+        before day: Date,
+        excludingLogUuid: String? = nil
+    ) -> Bool {
+        let uuidOpt: String? = kilterClimbUuid
+        let angleConst: Int? = angleDegrees
+        let dayConst: Date = day
+
+        do {
+            let descriptor: FetchDescriptor<ClimbEntry>
+            if let excludingLogUuid {
+                let excluded: String? = excludingLogUuid
+                descriptor = FetchDescriptor<ClimbEntry>(
+                    predicate: #Predicate { entry in
+                        entry.kilterClimbUuid == uuidOpt &&
+                        entry.kilterLogUuid != excluded &&
+                        entry.angleDegrees == angleConst &&
+                        entry.dateLogged < dayConst &&
+                        entry.isWorkInProgress == false
+                    },
+                    sortBy: [SortDescriptor(\ClimbEntry.dateLogged)]
+                )
+            } else {
+                descriptor = FetchDescriptor<ClimbEntry>(
+                    predicate: #Predicate { entry in
+                        entry.kilterClimbUuid == uuidOpt &&
+                        entry.angleDegrees == angleConst &&
+                        entry.dateLogged < dayConst &&
+                        entry.isWorkInProgress == false
+                    },
+                    sortBy: [SortDescriptor(\ClimbEntry.dateLogged)]
+                )
+            }
+            let priorCompleted = try context.fetch(descriptor)
+            return !priorCompleted.isEmpty
+        } catch {
+            return false
+        }
+    }
+
+    private static func findExistingEntry(for row: Row, in context: ModelContext) -> ClimbEntry? {
+        let logUuid: String? = row.logUuid
+        if let existing = (try? context.fetch(FetchDescriptor<ClimbEntry>(
+            predicate: #Predicate { entry in entry.kilterLogUuid == logUuid }
+        )))?.first {
+            return existing
+        }
+
+        let stable = stableID(logUuid: row.logUuid)
+        return (try? context.fetch(FetchDescriptor<ClimbEntry>(
+            predicate: #Predicate { entry in entry.id == stable }
+        )))?.first
+    }
+
+    private static func update(_ entry: ClimbEntry, with row: Row, previouslyClimbed: Bool) {
+        entry.climbType = .boulder
+        entry.grade = row.grade ?? ""
+        entry.feelsLikeGrade = row.feelsLikeGrade
+        entry.angleDegrees = row.angle
+        entry.style = "Kilter board"
+        entry.attempts = String(row.attempts)
+        entry.isWorkInProgress = !row.topped
+        entry.isPreviouslyClimbed = previouslyClimbed
+        entry.holdColor = nil
+        entry.gym = row.climbName ?? ""
+        entry.notes = row.climbName
+        entry.dateLogged = row.day
+        entry.tb2ClimbUUID = nil
+        entry.kilterLogUuid = row.logUuid
+        entry.kilterClimbUuid = row.climbUuid
+    }
+
+    private static func stableID(logUuid: String) -> UUID {
+        BoardSyncIdentity.deterministicUUID(from: "kilter|\(logUuid)")
+    }
+}

--- a/ClimbingProgram/features/climb/TB2Client.swift
+++ b/ClimbingProgram/features/climb/TB2Client.swift
@@ -9,11 +9,10 @@ import Foundation
 struct TB2Client {
     enum Board: String {
         case tension
-        case kilter
+
         var hostBase: String {
             switch self {
             case .tension: return "tensionboardapp2"
-            case .kilter:  return "kilterboardapp"
             }
         }
         var webBaseURL: URL { URL(string: "https://\(hostBase).com")! }
@@ -175,7 +174,7 @@ struct TB2Client {
             throw URLError(.badServerResponse)
         }
         if http.statusCode == 404 {
-            let alt = URL(string: url.absoluteString.replacing("/sync", with: "/api/v1/sync"))!
+            let alt = URL(string: url.absoluteString.replacingOccurrences(of: "/sync", with: "/api/v1/sync"))!
             var altReq = URLRequest(url: alt)
             altReq.httpMethod = "POST"
             for (k,v) in headers { altReq.setValue(v, forHTTPHeaderField: k) }

--- a/ClimbingProgram/features/climb/TB2SyncManager.swift
+++ b/ClimbingProgram/features/climb/TB2SyncManager.swift
@@ -6,7 +6,6 @@
 
 import Foundation
 import SwiftData
-import CryptoKit
 
 enum TB2SyncManager {
     struct DiffKey: Hashable {
@@ -57,7 +56,7 @@ enum TB2SyncManager {
         
         for b in bids {
             guard let uuid = b.climbUUID else { continue }
-            guard let date = TB2DateParser.parse(b.climbedAt) else { continue } // strict: no fallback to now
+            guard let date = BoardDateParser.parse(b.climbedAt) else { continue } // strict: no fallback to now
             let day = date
             let key = BidKey(uuid: uuid, day: day, angle: b.angle, isMirror: b.isMirror)
             var sum = bidSummary[key] ?? BidSum(tries: 0, comment: nil)
@@ -92,9 +91,9 @@ enum TB2SyncManager {
             let (dispNum, benchFlag) = displayedDiffFor(uuid: uuid, angle: angle)
             let loggedNum = a.difficulty
             let disp = dispNum ?? loggedNum
-            let loggedGrade = TB2GradeMapper.grade(of: loggedNum)
-            let displayedGrade = TB2GradeMapper.grade(of: disp)
-            guard let date = TB2DateParser.parse(a.climbedAt) else { continue }
+            let loggedGrade = BoardGradeMapper.grade(of: loggedNum)
+            let displayedGrade = BoardGradeMapper.grade(of: disp)
+            guard let date = BoardDateParser.parse(a.climbedAt) else { continue }
             let day = date
             let tries = (a.bidCount ?? a.attemptID ?? 1)
             let key = BidKey(uuid: uuid ?? "", day: day, angle: angle, isMirror: a.isMirror)
@@ -130,7 +129,7 @@ enum TB2SyncManager {
                 climbName: climbsByUUID[key.uuid],
                 loggedDifficultyNum: dispNum,
                 displayedDifficultyNum: dispNum,
-                loggedGrade: TB2GradeMapper.grade(of: dispNum),
+                loggedGrade: BoardGradeMapper.grade(of: dispNum),
                 displayedGrade: nil,
                 isBenchmark: benchFlag,
                 tries: sum.tries,
@@ -140,12 +139,7 @@ enum TB2SyncManager {
         }
         
         // 7) Upsert into SwiftData, mark previously climbed if any earlier entry exists with same tb2ClimbUUID
-        let styleName: String = {
-            switch board {
-            case .tension: return "Tension board"
-            case .kilter:  return "Kilter board"
-            }
-        }()
+        let styleName = "Tension board"
         
         // Sort outside and pass into a MainActor-isolated function to avoid Swift 6 Sendable captures
         let sortedRows = rows.sorted(by: { $0.day < $1.day })
@@ -281,26 +275,15 @@ enum TB2SyncManager {
     private static func stableID(climbUUID: String, day: Date, angle: Int?, isMirror: Bool?, isAscent: Bool) -> UUID {
         let dayEpoch = Int((day.timeIntervalSince1970 / 86400.0).rounded(.down))
         let key = "tb2|\(climbUUID)|\(dayEpoch)|\(angle ?? -999)|\((isMirror ?? false) ? 1 : 0)|\((isAscent) ? 1 : 0)"
-        return deterministicUUID(from: key)
-    }
-    
-    private static func deterministicUUID(from string: String) -> UUID {
-        let hash = SHA256.hash(data: Data(string.utf8))
-        let bytes = Array(hash.prefix(16))
-        let uuid = uuid_t(bytes[0],bytes[1],bytes[2],bytes[3],bytes[4],bytes[5],bytes[6],bytes[7],bytes[8],bytes[9],bytes[10],bytes[11],bytes[12],bytes[13],bytes[14],bytes[15])
-        return UUID(uuid: uuid)
+        return BoardSyncIdentity.deterministicUUID(from: key)
     }
     
     private static func dayKeyLocal(_ date: Date) -> String {
         var cal = Calendar(identifier: .gregorian)
         cal.timeZone = TimeZone.current   // ← match how startOfDay behaved before
         let localStart = cal.startOfDay(for: date)
-        let formatter = DateFormatter()
-        formatter.calendar = cal
-        formatter.timeZone = cal.timeZone
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateFormat = "yyyy-MM-dd"
-        return formatter.string(from: localStart)
+        let comps = cal.dateComponents([.year, .month, .day], from: localStart)
+        return String(format: "%04d-%02d-%02d", comps.year ?? 0, comps.month ?? 0, comps.day ?? 0)
     }
 
 
@@ -383,145 +366,4 @@ enum TB2SyncManager {
 
     }
 
-}
-
-// MARK: - Local helpers
-
-private struct TB2GradeMapper {
-    static let mappingCSV = """
-    difficulty,grade_label
-    1,1a/V0
-    2,1b/V0
-    3,1c/V0
-    4,2a/V0
-    5,2b/V0
-    6,2c/V0
-    7,3a/V0
-    8,3b/V0
-    9,3c/V0
-    10,4a/V0
-    11,4b/V0
-    12,4c/V0
-    13,5a/V1
-    14,5b/V1
-    15,5c/V2
-    16,6a/V3
-    17,6a+/V3
-    18,6b/V4
-    19,6b+/V4
-    20,6c/V5
-    21,6c+/V5
-    22,7a/V6
-    23,7a+/V7
-    24,7b/V8
-    25,7b+/V8
-    26,7c/V9
-    27,7c+/V10
-    28,8a/V11
-    29,8a+/V12
-    30,8b/V13
-    31,8b+/V14
-    32,8c/V15
-    33,8c+/V16
-    34,9a/V17
-    35,9a+/V18
-    36,9b/V19
-    37,9b+/V20
-    38,9c/V21
-    39,9c+/V22
-    """
-    
-    static let diffToGrade: [Int: String] = {
-        var out: [Int: String] = [:]
-        for line in mappingCSV.split(separator: "\n") {
-            let t = line.trimmingCharacters(in: .whitespacesAndNewlines)
-            if t.isEmpty || t.hasPrefix("#") || t.lowercased().hasPrefix("difficulty") { continue }
-            let parts = t.split(separator: ",", maxSplits: 1).map { String($0).trimmingCharacters(in: .whitespaces) }
-            guard parts.count >= 2, let n = Int(parts[0]) else { continue }
-            let left = leftPart(of: parts[1])
-            out[n] = left
-        }
-        return out
-    }()
-    
-    static func leftPart(of label: String) -> String {
-        let first = label.split(separator: "/", maxSplits: 1, omittingEmptySubsequences: false).first ?? Substring("")
-        let leftDot = first.split(separator: "·", maxSplits: 1, omittingEmptySubsequences: false).first ?? Substring("")
-        return String(leftDot).trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-    
-    static func grade(of number: Any?) -> String? {
-        guard let n = number else { return nil }
-        let value: Double?
-        if let i = n as? Int { value = Double(i) }
-        else if let d = n as? Double { value = d }
-        else if let s = n as? String { value = Double(s) }
-        else { value = nil }
-        guard let v = value else { return nil }
-        let key = Int((v).rounded())
-        return diffToGrade[key]
-    }
-}
-
-
-
-private enum TB2DateParser {
-    // ISO8601 variants
-    static let isoFull: ISO8601DateFormatter = {
-        let f = ISO8601DateFormatter()
-        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        return f
-    }()
-    static let isoBasic: ISO8601DateFormatter = {
-        let f = ISO8601DateFormatter()
-        f.formatOptions = [.withInternetDateTime]
-        return f
-    }()
-    
-    // Common custom patterns (UTC)
-    private static func makeFormatter(_ fmt: String, tzUTC: Bool = true) -> DateFormatter {
-        let f = DateFormatter()
-        f.locale = Locale(identifier: "en_US_POSIX")
-        f.timeZone = tzUTC ? TimeZone(secondsFromGMT: 0) : TimeZone.current
-        f.dateFormat = fmt
-        return f
-    }
-    static let f1 = makeFormatter("yyyy-MM-dd HH:mm:ss.SSSSSSXXXXX") // 2025-01-21 13:01:14.123456+00:00
-    static let f2 = makeFormatter("yyyy-MM-dd HH:mm:ss.SSSSSSxxxx")  // 2025-01-21 13:01:14.123456+0000
-    static let f3 = makeFormatter("yyyy-MM-dd HH:mm:ss.SSSSSS")      // 2025-01-21 13:01:14.123456
-    static let f4 = makeFormatter("yyyy-MM-dd HH:mm:ssXXXXX")        // 2025-01-21 13:01:14+00:00
-    static let f5 = makeFormatter("yyyy-MM-dd HH:mm:ssxxxx")         // 2025-01-21 13:01:14+0000
-    static let f6 = makeFormatter("yyyy-MM-dd HH:mm:ss")             // 2025-01-21 13:01:14
-    static let f7 = makeFormatter("yyyy-MM-dd")                      // 2025-01-21
-    static let f8 = makeFormatter("yyyy-MM-dd'T'HH:mm:ss.SSSSSSXXXXX")
-    static let f9 = makeFormatter("yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX")
-    static let f10 = makeFormatter("yyyy-MM-dd'T'HH:mm:ssXXXXX")
-    
-    static func parse(_ s: String?) -> Date? {
-        guard var s = s?.trimmingCharacters(in: .whitespacesAndNewlines), !s.isEmpty else { return nil }
-        
-        // Numeric epoch seconds or milliseconds
-        if CharacterSet.decimalDigits.isSuperset(of: CharacterSet(charactersIn: s)) {
-            if let v = Double(s) {
-                if s.count >= 13 { return Date(timeIntervalSince1970: v / 1000.0) }
-                if s.count >= 10 { return Date(timeIntervalSince1970: v) }
-            }
-        }
-        
-        // Try ISO8601
-        if let d = isoFull.date(from: s) { return d }
-        if let d = isoBasic.date(from: s) { return d }
-        
-        for f in [f1,f2,f3,f4,f5,f6,f7,f8,f9,f10] {
-            if let d = f.date(from: s) { return d }
-        }
-        
-        if s.hasSuffix(" UTC") {
-            s.removeLast(4)
-            for f in [f3, f6, f7] {
-                if let d = f.date(from: s) { return d }
-            }
-        }
-        return nil
-    }
 }

--- a/ClimbingProgram/shared/ClimbEntrySnapshotter.swift
+++ b/ClimbingProgram/shared/ClimbEntrySnapshotter.swift
@@ -40,6 +40,8 @@ struct ClimbEntrySnapshotter: UndoSnapshotting {
             notes: c.notes,
             dateLogged: c.dateLogged,
             tb2ClimbUUID: c.tb2ClimbUUID,
+            kilterLogUuid: c.kilterLogUuid,
+            kilterClimbUuid: c.kilterClimbUuid,
             media: mediaSnapshots
         )
     }
@@ -64,7 +66,9 @@ struct ClimbEntrySnapshotter: UndoSnapshotting {
             gym: s.gym,
             notes: s.notes,
             dateLogged: s.dateLogged,
-            tb2ClimbUUID: s.tb2ClimbUUID
+            tb2ClimbUUID: s.tb2ClimbUUID,
+            kilterLogUuid: s.kilterLogUuid,
+            kilterClimbUuid: s.kilterClimbUuid
         )
         context.insert(restored)
 
@@ -105,6 +109,8 @@ struct ClimbEntrySnapshotter: UndoSnapshotting {
         let notes: String?
         let dateLogged: Date
         let tb2ClimbUUID: String?
+        let kilterLogUuid: String?
+        let kilterClimbUuid: String?
 
         // NEW: snapshot of all media entries for this climb
         let media: [MediaSnapshot]

--- a/ClimbingProgramTests/KilterSyncTests.swift
+++ b/ClimbingProgramTests/KilterSyncTests.swift
@@ -1,0 +1,201 @@
+//
+//  KilterSyncTests.swift
+//  klettrack Tests
+//
+
+import Foundation
+import SwiftData
+import XCTest
+
+@testable import klettrack
+
+final class KilterSyncTests: ClimbingProgramTestSuite {
+    func testKilterClientBuildsLoginAndLogsRequests() async throws {
+        let recorder = KilterRequestRecorder(responses: [
+            (
+                Data("""
+                {
+                  "access_token": "token-123",
+                  "expires_in": 14400,
+                  "refresh_token": "refresh-123",
+                  "token_type": "Bearer"
+                }
+                """.utf8),
+                200
+            ),
+            (
+                Data("""
+                [
+                  {
+                    "logUuid": "log-1",
+                    "climbUuid": "climb-1",
+                    "angle": 40,
+                    "flashed": false,
+                    "topped": true,
+                    "attempts": 3,
+                    "createdAt": "2026-06-02T18:53:20.416361Z",
+                    "climbName": "Corporate Shrubbery",
+                    "currentDifficultyId": 19
+                  }
+                ]
+                """.utf8),
+                200
+            )
+        ])
+
+        let client = KilterClient(dataLoader: { request in
+            try await recorder.load(request)
+        })
+        let token = try await client.login(username: "user@example.com", password: "p&ss word+")
+        let logs = try await client.fetchLogs(accessToken: token.accessToken)
+
+        XCTAssertEqual(token.accessToken, "token-123")
+        XCTAssertEqual(logs.count, 1)
+        XCTAssertEqual(logs.first?.climbRating?.difficultyGradeId, nil)
+
+        let requests = await recorder.requests
+        XCTAssertEqual(requests.count, 2)
+        XCTAssertEqual(requests[0].url?.absoluteString, "https://idp.kiltergrips.com/realms/kilter/protocol/openid-connect/token")
+        XCTAssertEqual(requests[0].value(forHTTPHeaderField: "Content-Type"), "application/x-www-form-urlencoded")
+
+        let body = String(data: try XCTUnwrap(requests[0].httpBody), encoding: .utf8)
+        XCTAssertTrue(body?.contains("grant_type=password") == true)
+        XCTAssertTrue(body?.contains("client_id=kilter") == true)
+        XCTAssertTrue(body?.contains("username=user%40example.com") == true)
+        XCTAssertTrue(body?.contains("password=p%26ss+word%2B") == true)
+
+        XCTAssertEqual(requests[1].url?.absoluteString, "https://portal.kiltergrips.com/api/logs/")
+        XCTAssertEqual(requests[1].value(forHTTPHeaderField: "Authorization"), "Bearer token-123")
+    }
+
+    @MainActor
+    func testKilterApplyRowsInsertsUpdatesAndMarksPreviouslyClimbed() throws {
+        let firstDate = try XCTUnwrap(BoardDateParser.parse("2026-06-02T18:53:20.416361Z"))
+        let secondDate = try XCTUnwrap(BoardDateParser.parse("2026-06-03T18:53:20.416361Z"))
+
+        try KilterSyncManager.applyRows([
+            KilterSyncManager.Row(
+                logUuid: "log-1",
+                climbUuid: "climb-a",
+                day: firstDate,
+                topped: true,
+                angle: 40,
+                attempts: 1,
+                flashed: true,
+                climbName: "First",
+                grade: BoardGradeMapper.grade(of: 19),
+                feelsLikeGrade: nil
+            ),
+            KilterSyncManager.Row(
+                logUuid: "log-2",
+                climbUuid: "climb-a",
+                day: secondDate,
+                topped: true,
+                angle: 40,
+                attempts: 2,
+                flashed: false,
+                climbName: "Second",
+                grade: BoardGradeMapper.grade(of: 21),
+                feelsLikeGrade: BoardGradeMapper.grade(of: 20)
+            )
+        ], into: context)
+
+        var climbs = try context.fetch(FetchDescriptor<ClimbEntry>(sortBy: [SortDescriptor(\.dateLogged)]))
+        XCTAssertEqual(climbs.count, 2)
+        XCTAssertEqual(climbs[0].style, "Kilter board")
+        XCTAssertNil(climbs[0].tb2ClimbUUID)
+        XCTAssertEqual(climbs[0].kilterLogUuid, "log-1")
+        XCTAssertEqual(climbs[0].kilterClimbUuid, "climb-a")
+        XCTAssertEqual(climbs[0].isPreviouslyClimbed, false)
+        XCTAssertEqual(climbs[1].isPreviouslyClimbed, true)
+        XCTAssertEqual(climbs[1].feelsLikeGrade, "6c")
+
+        try KilterSyncManager.applyRows([
+            KilterSyncManager.Row(
+                logUuid: "log-1",
+                climbUuid: "climb-a",
+                day: firstDate,
+                topped: false,
+                angle: 40,
+                attempts: 3,
+                flashed: false,
+                climbName: "First updated",
+                grade: BoardGradeMapper.grade(of: 20),
+                feelsLikeGrade: nil
+            )
+        ], into: context)
+
+        climbs = try context.fetch(FetchDescriptor<ClimbEntry>(sortBy: [SortDescriptor(\.dateLogged)]))
+        XCTAssertEqual(climbs.count, 2)
+        let updated = try XCTUnwrap(climbs.first { $0.kilterLogUuid == "log-1" })
+        XCTAssertEqual(updated.attempts, "3")
+        XCTAssertEqual(updated.grade, "6c")
+        XCTAssertTrue(updated.isWorkInProgress)
+        XCTAssertEqual(updated.notes, "First updated")
+    }
+
+    func testKilterLogsDecodeWithOptionalClimbRating() throws {
+        let data = Data("""
+        [
+          {
+            "logUuid": "log-1",
+            "climbUuid": "climb-1",
+            "angle": 40,
+            "flashed": false,
+            "topped": true,
+            "attempts": 2,
+            "createdAt": "2026-06-02T18:32:24.065921Z",
+            "climbName": "Not in the Light",
+            "currentDifficultyId": 21,
+            "climbRating": {
+              "difficultyGradeId": 20,
+              "comment": "nice"
+            }
+          },
+          {
+            "logUuid": "log-2",
+            "climbUuid": "climb-2",
+            "angle": 30,
+            "flashed": true,
+            "topped": false,
+            "attempts": 1,
+            "createdAt": "2026-06-02T18:53:20.416361Z",
+            "climbName": "No Rating",
+            "currentDifficultyId": 19
+          }
+        ]
+        """.utf8)
+
+        let logs = try JSONDecoder().decode([KilterLog].self, from: data)
+
+        XCTAssertEqual(logs.count, 2)
+        XCTAssertEqual(logs[0].climbRating?.difficultyGradeId, 20)
+        XCTAssertNil(logs[1].climbRating)
+    }
+}
+
+private actor KilterRequestRecorder {
+    private var responses: [(Data, Int)]
+    private var storedRequests: [URLRequest] = []
+
+    init(responses: [(Data, Int)]) {
+        self.responses = responses
+    }
+
+    var requests: [URLRequest] {
+        storedRequests
+    }
+
+    func load(_ request: URLRequest) async throws -> (Data, URLResponse) {
+        storedRequests.append(request)
+        let response = responses.removeFirst()
+
+        let http = HTTPURLResponse(
+            url: request.url ?? URL(string: "https://example.com")!,
+            statusCode: response.1,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        return (response.0, http)
+    }
+}


### PR DESCRIPTION
## Summary
- refactor Kilter board sync onto the new Kilter backend flow
- split Kilter credentials from Tension Board credentials
- preserve PR #22 native features while adding Kilter sync tests

## Verification
- xcodebuild build-for-testing -project ClimbingProgram.xcodeproj -scheme ClimbingProgram -destination 'generic/platform=iOS' -derivedDataPath /private/tmp/kilter-sync-derived-data CODE_SIGNING_ALLOWED=NO