### PR TITLE
Fix plan ordering persistence and climb date editing

### DIFF
--- a/ClimbingProgram.xcodeproj/project.pbxproj
+++ b/ClimbingProgram.xcodeproj/project.pbxproj
@@ -285,7 +285,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6;
+				MARKETING_VERSION = 2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.somenoys.klettrack;
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME)";
 				PRODUCT_NAME = klettrack;
@@ -327,7 +327,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.6;
+				MARKETING_VERSION = 2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.somenoys.klettrack;
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME)";
 				PRODUCT_NAME = klettrack;

--- a/ClimbingProgram/features/plans/PlansViews.swift
+++ b/ClimbingProgram/features/plans/PlansViews.swift
@@ -3057,13 +3057,15 @@ private struct OrderedChosenExercisesView<RowContent: View>: View {
                 }
         }
         .onMove { source, destination in
+            var order = localOrder
+            order.move(fromOffsets: source, toOffset: destination)
+
             var transaction = Transaction()
             transaction.disablesAnimations = true
             withTransaction(transaction) {
-                var order = localOrder
-                order.move(fromOffsets: source, toOffset: destination)
                 localOrder = order
             }
+            persistOrder(order)
         }
         .moveDisabled(false)
         .onChange(of: editMode?.wrappedValue) { _, newValue in
@@ -3087,10 +3089,14 @@ private struct OrderedChosenExercisesView<RowContent: View>: View {
     }
 
     private func commitOrder() {
-        guard !localOrder.isEmpty else { return }
-        day.chosenExercises = localOrder
-        day.exerciseOrder = day.exerciseOrder.filter { localOrder.contains($0.key) }
-        for (idx, name) in localOrder.enumerated() {
+        persistOrder(localOrder)
+    }
+
+    private func persistOrder(_ orderedNames: [String]) {
+        guard !orderedNames.isEmpty else { return }
+        day.chosenExercises = orderedNames
+        day.exerciseOrder = day.exerciseOrder.filter { orderedNames.contains($0.key) }
+        for (idx, name) in orderedNames.enumerated() {
             day.exerciseOrder[name] = idx
         }
         reconcileExerciseIDOrder()

--- a/ClimbingProgram/shared/ClimbLogForm.swift
+++ b/ClimbingProgram/shared/ClimbLogForm.swift
@@ -302,6 +302,16 @@ struct ClimbLogForm: View {
                     }
                 }
 
+                ToolbarItem(placement: .principal) {
+                    DatePicker(
+                        "Climb date",
+                        selection: $selectedDate,
+                        displayedComponents: .date
+                    )
+                    .labelsHidden()
+                    .disabled(isSaving)
+                }
+
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Save") {
                         Task { await saveClimb(bulkCount: bulkCount) }


### PR DESCRIPTION
## Summary
- preserve PR #22 flat chosen-activity ordering while saving reordered plan activities immediately
- add a climb date picker to the add/edit climb form toolbar
- keep clone/bulk add behavior from latest main intact

## Verification
- xcodebuild -project ClimbingProgram.xcodeproj -scheme ClimbingProgram -destination 'platform=iOS Simulator,name=iPhone 17' build
- xcodebuild -project ClimbingProgram.xcodeproj -scheme ClimbingProgram -destination 'platform=iOS Simulator,name=iPhone 17' test