### PR TITLE
Add grade migration settings flow

### DIFF
--- a/ClimbingProgram/app/SettingsSheet.swift
+++ b/ClimbingProgram/app/SettingsSheet.swift
@@ -60,6 +60,24 @@ struct SettingsSheet: View {
                         }
                         .padding(.vertical, 1)
                     }
+
+                    NavigationLink {
+                        MigrateGradesView()
+                    } label: {
+                        HStack(alignment: .firstTextBaseline, spacing: 8) {
+                            Image(systemName: "arrow.triangle.2.circlepath")
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text("Migrate Grades")
+                                    .font(.body)
+                                Text("Bulk update logged grades for a gym")
+                                    .font(.footnote)
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(2)
+                            }
+                        }
+                        .padding(.vertical, 1)
+                    }
+
                     NavigationLink {
                         FeatureFlagsView()
                     } label: {

--- a/ClimbingProgram/app/SettingsSheet.swift
+++ b/ClimbingProgram/app/SettingsSheet.swift
@@ -60,7 +60,7 @@ struct SettingsSheet: View {
                         }
                         .padding(.vertical, 1)
                     }
-
+                    //migrate grades
                     NavigationLink {
                         MigrateGradesView()
                     } label: {
@@ -69,24 +69,7 @@ struct SettingsSheet: View {
                             VStack(alignment: .leading, spacing: 2) {
                                 Text("Migrate Grades")
                                     .font(.body)
-                                Text("Bulk update logged grades for a gym")
-                                    .font(.footnote)
-                                    .foregroundStyle(.secondary)
-                                    .lineLimit(2)
-                            }
-                        }
-                        .padding(.vertical, 1)
-                    }
-
-                    NavigationLink {
-                        FeatureFlagsView()
-                    } label: {
-                        HStack(alignment: .firstTextBaseline, spacing: 8) {
-                            Image(systemName: "switch.2")
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text("Feature Flags")
-                                    .font(.body)
-                                Text("Enable or disable experimental behavior")
+                                Text("Bulk update logged grades")
                                     .font(.footnote)
                                     .foregroundStyle(.secondary)
                                     .lineLimit(2)
@@ -112,6 +95,25 @@ struct SettingsSheet: View {
                         .padding(.vertical, 1)
                     }
                     
+                    //feature flags
+                    NavigationLink {
+                        FeatureFlagsView()
+                    } label: {
+                        HStack(alignment: .firstTextBaseline, spacing: 8) {
+                            Image(systemName: "switch.2")
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text("Feature Flags")
+                                    .font(.body)
+                                Text("Enable or disable different features")
+                                    .font(.footnote)
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(2)
+                            }
+                        }
+                        .padding(.vertical, 1)
+                    }
+
+                    //timertemplates
                     NavigationLink {
                         TimerTemplatesListView()
                     } label: {
@@ -128,7 +130,7 @@ struct SettingsSheet: View {
                         }
                         .padding(.vertical, 1)
                     }
-
+                    //BoardCredentials
                     NavigationLink {
                         BoardCredentialsSettingsView()
                     } label: {

--- a/ClimbingProgram/data/migrations/GradeMigrationService.swift
+++ b/ClimbingProgram/data/migrations/GradeMigrationService.swift
@@ -5,6 +5,27 @@ import SwiftData
 enum GradeMigrationService {
     struct Summary: Equatable {
         let count: Int
+        let rows: [RowSummary]
+    }
+
+    struct GradeCount: Equatable, Identifiable {
+        var id: String { grade }
+        let grade: String
+        let count: Int
+    }
+
+    struct Mapping: Equatable {
+        let oldGrade: String
+        let newGrade: String
+        let newFeelsLikeGrade: String?
+    }
+
+    struct RowSummary: Equatable, Identifiable {
+        var id: String { oldGrade }
+        let oldGrade: String
+        let newGrade: String
+        let newFeelsLikeGrade: String?
+        let count: Int
     }
 
     static func availableOldGrades(in context: ModelContext, gym: String) -> [String] {
@@ -19,6 +40,30 @@ enum GradeMigrationService {
         )
         let entries = (try? context.fetch(descriptor)) ?? []
         return distinctSortedGrades(from: entries)
+    }
+
+    static func gradeCounts(in context: ModelContext, gym: String) -> [GradeCount] {
+        let trimmedGym = gym.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedGym.isEmpty else { return [] }
+
+        let descriptor = FetchDescriptor<ClimbEntry>(
+            predicate: #Predicate { entry in
+                entry.gym == trimmedGym
+            },
+            sortBy: [SortDescriptor(\.grade, order: .forward)]
+        )
+        let entries = (try? context.fetch(descriptor)) ?? []
+        let counts = entries.reduce(into: [String: Int]()) { result, entry in
+            let grade = entry.grade.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !grade.isEmpty else { return }
+            result[grade, default: 0] += 1
+        }
+
+        return counts
+            .map { GradeCount(grade: $0.key, count: $0.value) }
+            .sorted { lhs, rhs in
+                lhs.grade.localizedStandardCompare(rhs.grade) == .orderedAscending
+            }
     }
 
     static func distinctSortedGrades(from entries: [ClimbEntry]) -> [String] {
@@ -44,6 +89,30 @@ enum GradeMigrationService {
         return (try? context.fetchCount(descriptor)) ?? 0
     }
 
+    static func preview(in context: ModelContext, gym: String, mappings: [Mapping]) -> Summary {
+        let activeMappings = sanitizedMappings(mappings)
+        guard !activeMappings.isEmpty else {
+            return Summary(count: 0, rows: [])
+        }
+
+        let counts = Dictionary(uniqueKeysWithValues: gradeCounts(in: context, gym: gym).map { ($0.grade, $0.count) })
+        let rows = activeMappings.compactMap { mapping -> RowSummary? in
+            let count = counts[mapping.oldGrade, default: 0]
+            guard count > 0 else { return nil }
+            return RowSummary(
+                oldGrade: mapping.oldGrade,
+                newGrade: mapping.newGrade,
+                newFeelsLikeGrade: mapping.newFeelsLikeGrade,
+                count: count
+            )
+        }
+
+        return Summary(
+            count: rows.reduce(0) { $0 + $1.count },
+            rows: rows
+        )
+    }
+
     @discardableResult
     static func migrate(
         in context: ModelContext,
@@ -58,7 +127,7 @@ enum GradeMigrationService {
         let trimmedFeelsLike = newFeelsLikeGrade?.trimmingCharacters(in: .whitespacesAndNewlines)
 
         guard !trimmedGym.isEmpty, !trimmedOldGrade.isEmpty, !trimmedNewGrade.isEmpty else {
-            return Summary(count: 0)
+            return Summary(count: 0, rows: [])
         }
 
         let descriptor = FetchDescriptor<ClimbEntry>(
@@ -76,6 +145,87 @@ enum GradeMigrationService {
         }
 
         try context.save()
-        return Summary(count: entries.count)
+        let rows = entries.isEmpty
+            ? []
+            : [
+                RowSummary(
+                    oldGrade: trimmedOldGrade,
+                    newGrade: trimmedNewGrade,
+                    newFeelsLikeGrade: trimmedFeelsLike?.isEmpty == false ? trimmedFeelsLike : nil,
+                    count: entries.count
+                )
+            ]
+        return Summary(count: entries.count, rows: rows)
+    }
+
+    @discardableResult
+    static func migrateAll(
+        in context: ModelContext,
+        gym: String,
+        mappings: [Mapping]
+    ) throws -> Summary {
+        let trimmedGym = gym.trimmingCharacters(in: .whitespacesAndNewlines)
+        let activeMappings = sanitizedMappings(mappings)
+        guard !trimmedGym.isEmpty, !activeMappings.isEmpty else {
+            return Summary(count: 0, rows: [])
+        }
+
+        let mappingByOldGrade = Dictionary(uniqueKeysWithValues: activeMappings.map { ($0.oldGrade, $0) })
+        let descriptor = FetchDescriptor<ClimbEntry>(
+            predicate: #Predicate { entry in
+                entry.gym == trimmedGym
+            }
+        )
+        let entries = try context.fetch(descriptor)
+
+        var changedCounts: [String: Int] = [:]
+        for entry in entries {
+            let originalGrade = entry.grade.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let mapping = mappingByOldGrade[originalGrade] else { continue }
+
+            entry.grade = mapping.newGrade
+            if let newFeelsLikeGrade = mapping.newFeelsLikeGrade {
+                entry.feelsLikeGrade = newFeelsLikeGrade
+            }
+            changedCounts[mapping.oldGrade, default: 0] += 1
+        }
+
+        try context.save()
+
+        let rows = activeMappings.compactMap { mapping -> RowSummary? in
+            let count = changedCounts[mapping.oldGrade, default: 0]
+            guard count > 0 else { return nil }
+            return RowSummary(
+                oldGrade: mapping.oldGrade,
+                newGrade: mapping.newGrade,
+                newFeelsLikeGrade: mapping.newFeelsLikeGrade,
+                count: count
+            )
+        }
+
+        return Summary(
+            count: rows.reduce(0) { $0 + $1.count },
+            rows: rows
+        )
+    }
+
+    private static func sanitizedMappings(_ mappings: [Mapping]) -> [Mapping] {
+        var seenOldGrades = Set<String>()
+        return mappings.compactMap { mapping in
+            let oldGrade = mapping.oldGrade.trimmingCharacters(in: .whitespacesAndNewlines)
+            let newGrade = mapping.newGrade.trimmingCharacters(in: .whitespacesAndNewlines)
+            let newFeelsLikeGrade = mapping.newFeelsLikeGrade?.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !oldGrade.isEmpty, !newGrade.isEmpty else { return nil }
+            guard !seenOldGrades.contains(oldGrade) else { return nil }
+            if oldGrade == newGrade && (newFeelsLikeGrade?.isEmpty ?? true) {
+                return nil
+            }
+            seenOldGrades.insert(oldGrade)
+            return Mapping(
+                oldGrade: oldGrade,
+                newGrade: newGrade,
+                newFeelsLikeGrade: newFeelsLikeGrade?.isEmpty == false ? newFeelsLikeGrade : nil
+            )
+        }
     }
 }

--- a/ClimbingProgram/data/migrations/GradeMigrationService.swift
+++ b/ClimbingProgram/data/migrations/GradeMigrationService.swift
@@ -1,0 +1,81 @@
+import Foundation
+import SwiftData
+
+@MainActor
+enum GradeMigrationService {
+    struct Summary: Equatable {
+        let count: Int
+    }
+
+    static func availableOldGrades(in context: ModelContext, gym: String) -> [String] {
+        let trimmedGym = gym.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedGym.isEmpty else { return [] }
+
+        let descriptor = FetchDescriptor<ClimbEntry>(
+            predicate: #Predicate { entry in
+                entry.gym == trimmedGym
+            },
+            sortBy: [SortDescriptor(\.grade, order: .forward)]
+        )
+        let entries = (try? context.fetch(descriptor)) ?? []
+        return distinctSortedGrades(from: entries)
+    }
+
+    static func distinctSortedGrades(from entries: [ClimbEntry]) -> [String] {
+        let grades = entries
+            .map { $0.grade.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+
+        return Array(Set(grades)).sorted { lhs, rhs in
+            lhs.localizedStandardCompare(rhs) == .orderedAscending
+        }
+    }
+
+    static func matchingCount(in context: ModelContext, gym: String, oldGrade: String) -> Int {
+        let trimmedGym = gym.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedOldGrade = oldGrade.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedGym.isEmpty, !trimmedOldGrade.isEmpty else { return 0 }
+
+        let descriptor = FetchDescriptor<ClimbEntry>(
+            predicate: #Predicate { entry in
+                entry.gym == trimmedGym && entry.grade == trimmedOldGrade
+            }
+        )
+        return (try? context.fetchCount(descriptor)) ?? 0
+    }
+
+    @discardableResult
+    static func migrate(
+        in context: ModelContext,
+        gym: String,
+        oldGrade: String,
+        newGrade: String,
+        newFeelsLikeGrade: String?
+    ) throws -> Summary {
+        let trimmedGym = gym.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedOldGrade = oldGrade.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedNewGrade = newGrade.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedFeelsLike = newFeelsLikeGrade?.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !trimmedGym.isEmpty, !trimmedOldGrade.isEmpty, !trimmedNewGrade.isEmpty else {
+            return Summary(count: 0)
+        }
+
+        let descriptor = FetchDescriptor<ClimbEntry>(
+            predicate: #Predicate { entry in
+                entry.gym == trimmedGym && entry.grade == trimmedOldGrade
+            }
+        )
+        let entries = try context.fetch(descriptor)
+
+        for entry in entries {
+            entry.grade = trimmedNewGrade
+            if let trimmedFeelsLike, !trimmedFeelsLike.isEmpty {
+                entry.feelsLikeGrade = trimmedFeelsLike
+            }
+        }
+
+        try context.save()
+        return Summary(count: entries.count)
+    }
+}

--- a/ClimbingProgram/data/migrations/GradeMigrationService.swift
+++ b/ClimbingProgram/data/migrations/GradeMigrationService.swift
@@ -17,14 +17,12 @@ enum GradeMigrationService {
     struct Mapping: Equatable {
         let oldGrade: String
         let newGrade: String
-        let newFeelsLikeGrade: String?
     }
 
     struct RowSummary: Equatable, Identifiable {
         var id: String { oldGrade }
         let oldGrade: String
         let newGrade: String
-        let newFeelsLikeGrade: String?
         let count: Int
     }
 
@@ -102,7 +100,6 @@ enum GradeMigrationService {
             return RowSummary(
                 oldGrade: mapping.oldGrade,
                 newGrade: mapping.newGrade,
-                newFeelsLikeGrade: mapping.newFeelsLikeGrade,
                 count: count
             )
         }
@@ -118,13 +115,11 @@ enum GradeMigrationService {
         in context: ModelContext,
         gym: String,
         oldGrade: String,
-        newGrade: String,
-        newFeelsLikeGrade: String?
+        newGrade: String
     ) throws -> Summary {
         let trimmedGym = gym.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedOldGrade = oldGrade.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedNewGrade = newGrade.trimmingCharacters(in: .whitespacesAndNewlines)
-        let trimmedFeelsLike = newFeelsLikeGrade?.trimmingCharacters(in: .whitespacesAndNewlines)
 
         guard !trimmedGym.isEmpty, !trimmedOldGrade.isEmpty, !trimmedNewGrade.isEmpty else {
             return Summary(count: 0, rows: [])
@@ -139,9 +134,6 @@ enum GradeMigrationService {
 
         for entry in entries {
             entry.grade = trimmedNewGrade
-            if let trimmedFeelsLike, !trimmedFeelsLike.isEmpty {
-                entry.feelsLikeGrade = trimmedFeelsLike
-            }
         }
 
         try context.save()
@@ -151,7 +143,6 @@ enum GradeMigrationService {
                 RowSummary(
                     oldGrade: trimmedOldGrade,
                     newGrade: trimmedNewGrade,
-                    newFeelsLikeGrade: trimmedFeelsLike?.isEmpty == false ? trimmedFeelsLike : nil,
                     count: entries.count
                 )
             ]
@@ -184,9 +175,6 @@ enum GradeMigrationService {
             guard let mapping = mappingByOldGrade[originalGrade] else { continue }
 
             entry.grade = mapping.newGrade
-            if let newFeelsLikeGrade = mapping.newFeelsLikeGrade {
-                entry.feelsLikeGrade = newFeelsLikeGrade
-            }
             changedCounts[mapping.oldGrade, default: 0] += 1
         }
 
@@ -198,7 +186,6 @@ enum GradeMigrationService {
             return RowSummary(
                 oldGrade: mapping.oldGrade,
                 newGrade: mapping.newGrade,
-                newFeelsLikeGrade: mapping.newFeelsLikeGrade,
                 count: count
             )
         }
@@ -214,17 +201,15 @@ enum GradeMigrationService {
         return mappings.compactMap { mapping in
             let oldGrade = mapping.oldGrade.trimmingCharacters(in: .whitespacesAndNewlines)
             let newGrade = mapping.newGrade.trimmingCharacters(in: .whitespacesAndNewlines)
-            let newFeelsLikeGrade = mapping.newFeelsLikeGrade?.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !oldGrade.isEmpty, !newGrade.isEmpty else { return nil }
             guard !seenOldGrades.contains(oldGrade) else { return nil }
-            if oldGrade == newGrade && (newFeelsLikeGrade?.isEmpty ?? true) {
+            if oldGrade == newGrade {
                 return nil
             }
             seenOldGrades.insert(oldGrade)
             return Mapping(
                 oldGrade: oldGrade,
-                newGrade: newGrade,
-                newFeelsLikeGrade: newFeelsLikeGrade?.isEmpty == false ? newFeelsLikeGrade : nil
+                newGrade: newGrade
             )
         }
     }

--- a/ClimbingProgram/features/climb/MigrateGradesView.swift
+++ b/ClimbingProgram/features/climb/MigrateGradesView.swift
@@ -84,14 +84,6 @@ struct MigrateGradesView: View {
         .safeAreaInset(edge: .bottom) {
             migrateButton
         }
-        .toolbar {
-            ToolbarItemGroup(placement: .keyboard) {
-                Spacer()
-                Button("Done") {
-                    focusedField = nil
-                }
-            }
-        }
         .alert("Migrate Grades?", isPresented: $showingConfirmation) {
             Button("Cancel", role: .cancel) { }
             Button("Migrate", role: .destructive) {
@@ -234,43 +226,46 @@ struct MigrateGradesView: View {
 }
 
 private struct GradeMappingHeader: View {
+    private let targetColumnWidth: CGFloat = 112
+
     var body: some View {
-        Grid(horizontalSpacing: 12, verticalSpacing: 8) {
-            GridRow {
-                Text("Current")
-                Text("Target")
-            }
-            .font(.caption)
-            .foregroundStyle(.secondary)
+        HStack(spacing: 12) {
+            Text("Current")
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Text("Target")
+                .frame(width: targetColumnWidth, alignment: .leading)
         }
+        .font(.caption)
+        .foregroundStyle(.secondary)
     }
 }
 
 private struct GradeMappingRow: View {
+    private let targetColumnWidth: CGFloat = 112
+
     @Binding var draft: MigrateGradesView.GradeMappingDraft
     var focusedField: FocusState<MigrateGradesView.FocusedField?>.Binding
 
     var body: some View {
-        Grid(horizontalSpacing: 12, verticalSpacing: 8) {
-            GridRow {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(draft.oldGrade)
-                        .font(.body)
-                    Text("\(draft.count) \(draft.count == 1 ? "climb" : "climbs")")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-                .gridColumnAlignment(.leading)
-
-                TextField("No change", text: $draft.newGrade)
-                    .textInputAutocapitalization(.never)
-                    .autocorrectionDisabled()
-                    .focused(focusedField, equals: .newGrade(draft.id))
-                    .submitLabel(.done)
-                    .onSubmit {
-                        focusedField.wrappedValue = nil
-                    }
+        HStack(alignment: .firstTextBaseline, spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(draft.oldGrade)
+                    .font(.body)
+                Text("\(draft.count) \(draft.count == 1 ? "climb" : "climbs")")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            TextField("No change", text: $draft.newGrade)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .focused(focusedField, equals: .newGrade(draft.id))
+                .submitLabel(.done)
+                .frame(width: targetColumnWidth, alignment: .leading)
+                .onSubmit {
+                    focusedField.wrappedValue = nil
+                }
         }
         .padding(.vertical, 4)
     }

--- a/ClimbingProgram/features/climb/MigrateGradesView.swift
+++ b/ClimbingProgram/features/climb/MigrateGradesView.swift
@@ -7,7 +7,6 @@ struct MigrateGradesView: View {
         let oldGrade: String
         let count: Int
         var newGrade: String = ""
-        var newFeelsLikeGrade: String = ""
     }
 
     private struct ResultAlert: Identifiable {
@@ -18,7 +17,6 @@ struct MigrateGradesView: View {
 
     fileprivate enum FocusedField: Hashable {
         case newGrade(UUID)
-        case newFeelsLikeGrade(UUID)
     }
 
     @Environment(\.modelContext) private var context
@@ -41,8 +39,7 @@ struct MigrateGradesView: View {
         mappingDrafts.map {
             GradeMigrationService.Mapping(
                 oldGrade: $0.oldGrade,
-                newGrade: $0.newGrade,
-                newFeelsLikeGrade: $0.newFeelsLikeGrade
+                newGrade: $0.newGrade
             )
         }
     }
@@ -61,11 +58,7 @@ struct MigrateGradesView: View {
         }
 
         let rows = previewSummary.rows.map { row in
-            var text = "\(row.count) climb\(row.count == 1 ? "" : "s"): \(row.oldGrade) -> \(row.newGrade)"
-            if let newFeelsLikeGrade = row.newFeelsLikeGrade {
-                text += " (My Grade: \(newFeelsLikeGrade))"
-            }
-            return text
+            "\(row.count) climb\(row.count == 1 ? "" : "s"): \(row.oldGrade) -> \(row.newGrade)"
         }
 
         return """
@@ -162,7 +155,7 @@ struct MigrateGradesView: View {
         } header: {
             Text("Grade Mapping")
         } footer: {
-            Text("Leave a target grade blank to keep that grade unchanged. Blank My Grade leaves existing My Grade values unchanged.")
+            Text("Leave a target grade blank to keep that grade unchanged.")
         }
     }
 
@@ -182,9 +175,6 @@ struct MigrateGradesView: View {
                         HStack(spacing: 8) {
                             Text(row.count, format: .number)
                             Text(row.count == 1 ? "climb" : "climbs")
-                            if let newFeelsLikeGrade = row.newFeelsLikeGrade {
-                                Text("My Grade: \(newFeelsLikeGrade)")
-                            }
                         }
                         .font(.footnote)
                         .foregroundStyle(.secondary)
@@ -249,7 +239,6 @@ private struct GradeMappingHeader: View {
             GridRow {
                 Text("Current")
                 Text("Target")
-                Text("My Grade")
             }
             .font(.caption)
             .foregroundStyle(.secondary)
@@ -277,15 +266,6 @@ private struct GradeMappingRow: View {
                     .textInputAutocapitalization(.never)
                     .autocorrectionDisabled()
                     .focused(focusedField, equals: .newGrade(draft.id))
-                    .submitLabel(.done)
-                    .onSubmit {
-                        focusedField.wrappedValue = nil
-                    }
-
-                TextField("Optional", text: $draft.newFeelsLikeGrade)
-                    .textInputAutocapitalization(.never)
-                    .autocorrectionDisabled()
-                    .focused(focusedField, equals: .newFeelsLikeGrade(draft.id))
                     .submitLabel(.done)
                     .onSubmit {
                         focusedField.wrappedValue = nil

--- a/ClimbingProgram/features/climb/MigrateGradesView.swift
+++ b/ClimbingProgram/features/climb/MigrateGradesView.swift
@@ -2,15 +2,23 @@ import SwiftData
 import SwiftUI
 
 struct MigrateGradesView: View {
+    fileprivate struct GradeMappingDraft: Identifiable, Equatable {
+        let id = UUID()
+        let oldGrade: String
+        let count: Int
+        var newGrade: String = ""
+        var newFeelsLikeGrade: String = ""
+    }
+
     private struct ResultAlert: Identifiable {
         let id = UUID()
         let title: String
         let message: String
     }
 
-    private enum FocusedField: Hashable {
-        case newGrade
-        case newFeelsLikeGrade
+    fileprivate enum FocusedField: Hashable {
+        case newGrade(UUID)
+        case newFeelsLikeGrade(UUID)
     }
 
     @Environment(\.modelContext) private var context
@@ -18,9 +26,7 @@ struct MigrateGradesView: View {
     @Query(sort: [SortDescriptor(\ClimbGym.name, order: .forward)]) private var gyms: [ClimbGym]
 
     @State private var selectedGym = ""
-    @State private var selectedOldGrade = ""
-    @State private var newGrade = ""
-    @State private var newFeelsLikeGrade = ""
+    @State private var mappingDrafts: [GradeMappingDraft] = []
     @State private var showingConfirmation = false
     @State private var resultAlert: ResultAlert?
     @FocusState private var focusedField: FocusedField?
@@ -31,45 +37,56 @@ struct MigrateGradesView: View {
             .filter { !$0.isEmpty }
     }
 
-    private var oldGradeOptions: [String] {
-        GradeMigrationService.availableOldGrades(in: context, gym: selectedGym)
+    private var mappings: [GradeMigrationService.Mapping] {
+        mappingDrafts.map {
+            GradeMigrationService.Mapping(
+                oldGrade: $0.oldGrade,
+                newGrade: $0.newGrade,
+                newFeelsLikeGrade: $0.newFeelsLikeGrade
+            )
+        }
     }
 
-    private var trimmedNewGrade: String {
-        newGrade.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    private var trimmedNewFeelsLikeGrade: String {
-        newFeelsLikeGrade.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    private var affectedCount: Int {
-        GradeMigrationService.matchingCount(in: context, gym: selectedGym, oldGrade: selectedOldGrade)
+    private var previewSummary: GradeMigrationService.Summary {
+        GradeMigrationService.preview(in: context, gym: selectedGym, mappings: mappings)
     }
 
     private var canMigrate: Bool {
-        !selectedGym.isEmpty &&
-        !selectedOldGrade.isEmpty &&
-        !trimmedNewGrade.isEmpty
+        !selectedGym.isEmpty && previewSummary.count > 0
     }
 
     private var confirmationMessage: String {
-        var message = "This will change \(affectedCount) climb\(affectedCount == 1 ? "" : "s") at \(selectedGym) from \(selectedOldGrade) to \(trimmedNewGrade). You can migrate back later by running this again with the grades swapped."
-        if !trimmedNewFeelsLikeGrade.isEmpty {
-            message += "\n\nMy Grade will be set to \(trimmedNewFeelsLikeGrade)."
+        guard !previewSummary.rows.isEmpty else {
+            return "No grades will be changed."
         }
-        return message
+
+        let rows = previewSummary.rows.map { row in
+            var text = "\(row.count) climb\(row.count == 1 ? "" : "s"): \(row.oldGrade) -> \(row.newGrade)"
+            if let newFeelsLikeGrade = row.newFeelsLikeGrade {
+                text += " (My Grade: \(newFeelsLikeGrade))"
+            }
+            return text
+        }
+
+        return """
+        This will change \(previewSummary.count) climb\(previewSummary.count == 1 ? "" : "s") at \(selectedGym):
+
+        \(rows.joined(separator: "\n"))
+
+        The migration is based on the current grades before any row is changed, so remapping chains like 4 -> 5 and 5 -> 6 will not cascade.
+        """
     }
 
     var body: some View {
         List {
-            migrationSection
+            gymSection
+            mappingsSection
             previewSection
         }
         .navigationTitle("Migrate Grades")
         .navigationBarTitleDisplayMode(.large)
         .onChange(of: selectedGym) {
-            resetOldGradeIfNeeded()
+            loadMappingDrafts()
         }
         .safeAreaInset(edge: .bottom) {
             migrateButton
@@ -99,7 +116,7 @@ struct MigrateGradesView: View {
         }
     }
 
-    private var migrationSection: some View {
+    private var gymSection: some View {
         Section {
             Picker("Gym", selection: $selectedGym) {
                 Text("Select Gym").tag("")
@@ -108,41 +125,81 @@ struct MigrateGradesView: View {
                 }
             }
             .disabled(gymNames.isEmpty)
+        } header: {
+            Text("Gym")
+        }
+    }
 
-            Picker("Old Grade", selection: $selectedOldGrade) {
-                Text("Select Grade").tag("")
-                ForEach(oldGradeOptions, id: \.self) { grade in
-                    Text(grade).tag(grade)
+    private var mappingsSection: some View {
+        Section {
+            if gymNames.isEmpty {
+                ContentUnavailableView(
+                    "No Gyms",
+                    systemImage: "building.2",
+                    description: Text("Add gyms before migrating grades.")
+                )
+            } else if selectedGym.isEmpty {
+                ContentUnavailableView(
+                    "Select Gym",
+                    systemImage: "building.2",
+                    description: Text("Choose a gym to see its logged grades.")
+                )
+            } else if mappingDrafts.isEmpty {
+                ContentUnavailableView(
+                    "No Grades",
+                    systemImage: "number",
+                    description: Text("This gym does not have logged grades yet.")
+                )
+            } else {
+                GradeMappingHeader()
+                ForEach($mappingDrafts) { $draft in
+                    GradeMappingRow(
+                        draft: $draft,
+                        focusedField: $focusedField
+                    )
                 }
             }
-            .disabled(selectedGym.isEmpty || oldGradeOptions.isEmpty)
-
-            TextField("New grade", text: $newGrade)
-                .textInputAutocapitalization(.never)
-                .autocorrectionDisabled()
-                .focused($focusedField, equals: .newGrade)
-                .submitLabel(.done)
-                .onSubmit {
-                    focusedField = nil
-                }
-
-            TextField("New My Grade (optional)", text: $newFeelsLikeGrade)
-                .textInputAutocapitalization(.never)
-                .autocorrectionDisabled()
-                .focused($focusedField, equals: .newFeelsLikeGrade)
-                .submitLabel(.done)
-                .onSubmit {
-                    focusedField = nil
-                }
         } header: {
-            Text("Migration")
+            Text("Grade Mapping")
         } footer: {
-            Text("Blank My Grade leaves existing My Grade values unchanged.")
+            Text("Leave a target grade blank to keep that grade unchanged. Blank My Grade leaves existing My Grade values unchanged.")
+        }
+    }
+
+    private var previewSection: some View {
+        Section {
+            LabeledContent("Affected Climbs") {
+                Text(previewSummary.count, format: .number)
+            }
+
+            if previewSummary.rows.isEmpty {
+                Text("No grade changes selected.")
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(previewSummary.rows) { row in
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("\(row.oldGrade) -> \(row.newGrade)")
+                        HStack(spacing: 8) {
+                            Text(row.count, format: .number)
+                            Text(row.count == 1 ? "climb" : "climbs")
+                            if let newFeelsLikeGrade = row.newFeelsLikeGrade {
+                                Text("My Grade: \(newFeelsLikeGrade)")
+                            }
+                        }
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                    }
+                    .padding(.vertical, 2)
+                }
+            }
+        } header: {
+            Text("Preview")
         }
     }
 
     private var migrateButton: some View {
         Button {
+            focusedField = nil
             showingConfirmation = true
         } label: {
             Label("Migrate Grades", systemImage: "arrow.triangle.2.circlepath")
@@ -158,54 +215,21 @@ struct MigrateGradesView: View {
         .background(.bar)
     }
 
-    private var previewSection: some View {
-        Section {
-            if gymNames.isEmpty {
-                ContentUnavailableView(
-                    "No Gyms",
-                    systemImage: "building.2",
-                    description: Text("Add gyms before migrating grades.")
-                )
-            } else if !selectedGym.isEmpty && oldGradeOptions.isEmpty {
-                ContentUnavailableView(
-                    "No Grades",
-                    systemImage: "number",
-                    description: Text("This gym does not have logged grades yet.")
-                )
-            } else {
-                LabeledContent("Affected Climbs") {
-                    Text(affectedCount, format: .number)
-                }
-                if !selectedGym.isEmpty {
-                    LabeledContent("Gym", value: selectedGym)
-                }
-                if !selectedOldGrade.isEmpty {
-                    LabeledContent("Old Grade", value: selectedOldGrade)
-                }
-            }
-        } header: {
-            Text("Preview")
-        }
-    }
-
-    private func resetOldGradeIfNeeded() {
-        if !oldGradeOptions.contains(selectedOldGrade) {
-            selectedOldGrade = ""
-        }
+    private func loadMappingDrafts() {
+        focusedField = nil
+        mappingDrafts = GradeMigrationService
+            .gradeCounts(in: context, gym: selectedGym)
+            .map { GradeMappingDraft(oldGrade: $0.grade, count: $0.count) }
     }
 
     private func runMigration() {
         do {
-            let summary = try GradeMigrationService.migrate(
+            let summary = try GradeMigrationService.migrateAll(
                 in: context,
                 gym: selectedGym,
-                oldGrade: selectedOldGrade,
-                newGrade: newGrade,
-                newFeelsLikeGrade: newFeelsLikeGrade
+                mappings: mappings
             )
-            newGrade = ""
-            newFeelsLikeGrade = ""
-            resetOldGradeIfNeeded()
+            loadMappingDrafts()
             resultAlert = ResultAlert(
                 title: "Migration Complete",
                 message: "Updated \(summary.count) climb\(summary.count == 1 ? "" : "s")."
@@ -216,6 +240,59 @@ struct MigrateGradesView: View {
                 message: error.localizedDescription
             )
         }
+    }
+}
+
+private struct GradeMappingHeader: View {
+    var body: some View {
+        Grid(horizontalSpacing: 12, verticalSpacing: 8) {
+            GridRow {
+                Text("Current")
+                Text("Target")
+                Text("My Grade")
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+    }
+}
+
+private struct GradeMappingRow: View {
+    @Binding var draft: MigrateGradesView.GradeMappingDraft
+    var focusedField: FocusState<MigrateGradesView.FocusedField?>.Binding
+
+    var body: some View {
+        Grid(horizontalSpacing: 12, verticalSpacing: 8) {
+            GridRow {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(draft.oldGrade)
+                        .font(.body)
+                    Text("\(draft.count) \(draft.count == 1 ? "climb" : "climbs")")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .gridColumnAlignment(.leading)
+
+                TextField("No change", text: $draft.newGrade)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .focused(focusedField, equals: .newGrade(draft.id))
+                    .submitLabel(.done)
+                    .onSubmit {
+                        focusedField.wrappedValue = nil
+                    }
+
+                TextField("Optional", text: $draft.newFeelsLikeGrade)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .focused(focusedField, equals: .newFeelsLikeGrade(draft.id))
+                    .submitLabel(.done)
+                    .onSubmit {
+                        focusedField.wrappedValue = nil
+                    }
+            }
+        }
+        .padding(.vertical, 4)
     }
 }
 

--- a/ClimbingProgram/features/climb/MigrateGradesView.swift
+++ b/ClimbingProgram/features/climb/MigrateGradesView.swift
@@ -8,6 +8,11 @@ struct MigrateGradesView: View {
         let message: String
     }
 
+    private enum FocusedField: Hashable {
+        case newGrade
+        case newFeelsLikeGrade
+    }
+
     @Environment(\.modelContext) private var context
 
     @Query(sort: [SortDescriptor(\ClimbGym.name, order: .forward)]) private var gyms: [ClimbGym]
@@ -18,6 +23,7 @@ struct MigrateGradesView: View {
     @State private var newFeelsLikeGrade = ""
     @State private var showingConfirmation = false
     @State private var resultAlert: ResultAlert?
+    @FocusState private var focusedField: FocusedField?
 
     private var gymNames: [String] {
         gyms
@@ -68,6 +74,14 @@ struct MigrateGradesView: View {
         .safeAreaInset(edge: .bottom) {
             migrateButton
         }
+        .toolbar {
+            ToolbarItemGroup(placement: .keyboard) {
+                Spacer()
+                Button("Done") {
+                    focusedField = nil
+                }
+            }
+        }
         .alert("Migrate Grades?", isPresented: $showingConfirmation) {
             Button("Cancel", role: .cancel) { }
             Button("Migrate", role: .destructive) {
@@ -106,10 +120,20 @@ struct MigrateGradesView: View {
             TextField("New grade", text: $newGrade)
                 .textInputAutocapitalization(.never)
                 .autocorrectionDisabled()
+                .focused($focusedField, equals: .newGrade)
+                .submitLabel(.done)
+                .onSubmit {
+                    focusedField = nil
+                }
 
             TextField("New My Grade (optional)", text: $newFeelsLikeGrade)
                 .textInputAutocapitalization(.never)
                 .autocorrectionDisabled()
+                .focused($focusedField, equals: .newFeelsLikeGrade)
+                .submitLabel(.done)
+                .onSubmit {
+                    focusedField = nil
+                }
         } header: {
             Text("Migration")
         } footer: {

--- a/ClimbingProgram/features/climb/MigrateGradesView.swift
+++ b/ClimbingProgram/features/climb/MigrateGradesView.swift
@@ -1,0 +1,203 @@
+import SwiftData
+import SwiftUI
+
+struct MigrateGradesView: View {
+    private struct ResultAlert: Identifiable {
+        let id = UUID()
+        let title: String
+        let message: String
+    }
+
+    @Environment(\.modelContext) private var context
+
+    @Query(sort: [SortDescriptor(\ClimbGym.name, order: .forward)]) private var gyms: [ClimbGym]
+
+    @State private var selectedGym = ""
+    @State private var selectedOldGrade = ""
+    @State private var newGrade = ""
+    @State private var newFeelsLikeGrade = ""
+    @State private var showingConfirmation = false
+    @State private var resultAlert: ResultAlert?
+
+    private var gymNames: [String] {
+        gyms
+            .map { $0.name.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    private var oldGradeOptions: [String] {
+        GradeMigrationService.availableOldGrades(in: context, gym: selectedGym)
+    }
+
+    private var trimmedNewGrade: String {
+        newGrade.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var trimmedNewFeelsLikeGrade: String {
+        newFeelsLikeGrade.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var affectedCount: Int {
+        GradeMigrationService.matchingCount(in: context, gym: selectedGym, oldGrade: selectedOldGrade)
+    }
+
+    private var canMigrate: Bool {
+        !selectedGym.isEmpty &&
+        !selectedOldGrade.isEmpty &&
+        !trimmedNewGrade.isEmpty
+    }
+
+    private var confirmationMessage: String {
+        var message = "This will change \(affectedCount) climb\(affectedCount == 1 ? "" : "s") at \(selectedGym) from \(selectedOldGrade) to \(trimmedNewGrade). You can migrate back later by running this again with the grades swapped."
+        if !trimmedNewFeelsLikeGrade.isEmpty {
+            message += "\n\nMy Grade will be set to \(trimmedNewFeelsLikeGrade)."
+        }
+        return message
+    }
+
+    var body: some View {
+        List {
+            migrationSection
+            previewSection
+        }
+        .navigationTitle("Migrate Grades")
+        .navigationBarTitleDisplayMode(.large)
+        .onChange(of: selectedGym) {
+            resetOldGradeIfNeeded()
+        }
+        .safeAreaInset(edge: .bottom) {
+            migrateButton
+        }
+        .alert("Migrate Grades?", isPresented: $showingConfirmation) {
+            Button("Cancel", role: .cancel) { }
+            Button("Migrate", role: .destructive) {
+                runMigration()
+            }
+        } message: {
+            Text(confirmationMessage)
+        }
+        .alert(item: $resultAlert) { alert in
+            Alert(
+                title: Text(alert.title),
+                message: Text(alert.message),
+                dismissButton: .default(Text("OK"))
+            )
+        }
+    }
+
+    private var migrationSection: some View {
+        Section {
+            Picker("Gym", selection: $selectedGym) {
+                Text("Select Gym").tag("")
+                ForEach(gymNames, id: \.self) { gym in
+                    Text(gym).tag(gym)
+                }
+            }
+            .disabled(gymNames.isEmpty)
+
+            Picker("Old Grade", selection: $selectedOldGrade) {
+                Text("Select Grade").tag("")
+                ForEach(oldGradeOptions, id: \.self) { grade in
+                    Text(grade).tag(grade)
+                }
+            }
+            .disabled(selectedGym.isEmpty || oldGradeOptions.isEmpty)
+
+            TextField("New grade", text: $newGrade)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+
+            TextField("New My Grade (optional)", text: $newFeelsLikeGrade)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+        } header: {
+            Text("Migration")
+        } footer: {
+            Text("Blank My Grade leaves existing My Grade values unchanged.")
+        }
+    }
+
+    private var migrateButton: some View {
+        Button {
+            showingConfirmation = true
+        } label: {
+            Label("Migrate Grades", systemImage: "arrow.triangle.2.circlepath")
+                .font(.headline)
+                .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.borderedProminent)
+        .controlSize(.large)
+        .disabled(!canMigrate)
+        .padding(.horizontal)
+        .padding(.top, 12)
+        .padding(.bottom, 8)
+        .background(.bar)
+    }
+
+    private var previewSection: some View {
+        Section {
+            if gymNames.isEmpty {
+                ContentUnavailableView(
+                    "No Gyms",
+                    systemImage: "building.2",
+                    description: Text("Add gyms before migrating grades.")
+                )
+            } else if !selectedGym.isEmpty && oldGradeOptions.isEmpty {
+                ContentUnavailableView(
+                    "No Grades",
+                    systemImage: "number",
+                    description: Text("This gym does not have logged grades yet.")
+                )
+            } else {
+                LabeledContent("Affected Climbs") {
+                    Text(affectedCount, format: .number)
+                }
+                if !selectedGym.isEmpty {
+                    LabeledContent("Gym", value: selectedGym)
+                }
+                if !selectedOldGrade.isEmpty {
+                    LabeledContent("Old Grade", value: selectedOldGrade)
+                }
+            }
+        } header: {
+            Text("Preview")
+        }
+    }
+
+    private func resetOldGradeIfNeeded() {
+        if !oldGradeOptions.contains(selectedOldGrade) {
+            selectedOldGrade = ""
+        }
+    }
+
+    private func runMigration() {
+        do {
+            let summary = try GradeMigrationService.migrate(
+                in: context,
+                gym: selectedGym,
+                oldGrade: selectedOldGrade,
+                newGrade: newGrade,
+                newFeelsLikeGrade: newFeelsLikeGrade
+            )
+            newGrade = ""
+            newFeelsLikeGrade = ""
+            resetOldGradeIfNeeded()
+            resultAlert = ResultAlert(
+                title: "Migration Complete",
+                message: "Updated \(summary.count) climb\(summary.count == 1 ? "" : "s")."
+            )
+        } catch {
+            resultAlert = ResultAlert(
+                title: "Migration Failed",
+                message: error.localizedDescription
+            )
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        MigrateGradesView()
+    }
+    .modelContainer(for: [ClimbEntry.self, ClimbGym.self], inMemory: true)
+}

--- a/ClimbingProgramTests/GradeMigrationServiceTests.swift
+++ b/ClimbingProgramTests/GradeMigrationServiceTests.swift
@@ -1,0 +1,124 @@
+import SwiftData
+import XCTest
+@testable import klettrack
+
+final class GradeMigrationServiceTests: ClimbingProgramTestSuite {
+    @MainActor
+    func testMigrationUpdatesOnlyMatchingGymAndGrade() throws {
+        let matchingOne = makeClimb(gym: "Ostbloc", grade: "V4", feelsLikeGrade: "V5")
+        let matchingTwo = makeClimb(gym: "Ostbloc", grade: "V4", feelsLikeGrade: nil)
+        let sameGradeOtherGym = makeClimb(gym: "Bouldergarten", grade: "V4", feelsLikeGrade: "V4")
+        let otherGradeSameGym = makeClimb(gym: "Ostbloc", grade: "V5", feelsLikeGrade: "V5")
+
+        let summary = try GradeMigrationService.migrate(
+            in: context,
+            gym: "Ostbloc",
+            oldGrade: "V4",
+            newGrade: "V6",
+            newFeelsLikeGrade: nil
+        )
+
+        XCTAssertEqual(summary.count, 2)
+        XCTAssertEqual(matchingOne.grade, "V6")
+        XCTAssertEqual(matchingTwo.grade, "V6")
+        XCTAssertEqual(sameGradeOtherGym.grade, "V4")
+        XCTAssertEqual(otherGradeSameGym.grade, "V5")
+    }
+
+    @MainActor
+    func testMigrationUpdatesFeelsLikeGradeWhenProvided() throws {
+        let climb = makeClimb(gym: "Ostbloc", grade: "6a", feelsLikeGrade: "6b")
+
+        let summary = try GradeMigrationService.migrate(
+            in: context,
+            gym: "Ostbloc",
+            oldGrade: "6a",
+            newGrade: "6c",
+            newFeelsLikeGrade: " 7a "
+        )
+
+        XCTAssertEqual(summary.count, 1)
+        XCTAssertEqual(climb.grade, "6c")
+        XCTAssertEqual(climb.feelsLikeGrade, "7a")
+    }
+
+    @MainActor
+    func testMigrationLeavesFeelsLikeGradeUnchangedWhenBlank() throws {
+        let climbWithValue = makeClimb(gym: "Ostbloc", grade: "6a", feelsLikeGrade: "6b")
+        let climbWithoutValue = makeClimb(gym: "Ostbloc", grade: "6a", feelsLikeGrade: nil)
+
+        let summary = try GradeMigrationService.migrate(
+            in: context,
+            gym: "Ostbloc",
+            oldGrade: "6a",
+            newGrade: "6c",
+            newFeelsLikeGrade: " "
+        )
+
+        XCTAssertEqual(summary.count, 2)
+        XCTAssertEqual(climbWithValue.grade, "6c")
+        XCTAssertEqual(climbWithValue.feelsLikeGrade, "6b")
+        XCTAssertEqual(climbWithoutValue.grade, "6c")
+        XCTAssertNil(climbWithoutValue.feelsLikeGrade)
+    }
+
+    @MainActor
+    func testMigrationReturnsZeroWhenNoEntriesMatch() throws {
+        let climb = makeClimb(gym: "Ostbloc", grade: "V4", feelsLikeGrade: "V5")
+
+        let summary = try GradeMigrationService.migrate(
+            in: context,
+            gym: "Ostbloc",
+            oldGrade: "V3",
+            newGrade: "V5",
+            newFeelsLikeGrade: "V6"
+        )
+
+        XCTAssertEqual(summary.count, 0)
+        XCTAssertEqual(climb.grade, "V4")
+        XCTAssertEqual(climb.feelsLikeGrade, "V5")
+    }
+
+    @MainActor
+    func testAvailableOldGradesReturnsDistinctSortedGradesForSelectedGym() {
+        makeClimb(gym: "Ostbloc", grade: "V5")
+        makeClimb(gym: "Ostbloc", grade: "V3")
+        makeClimb(gym: "Ostbloc", grade: "V5")
+        makeClimb(gym: "Bouldergarten", grade: "V1")
+
+        let grades = GradeMigrationService.availableOldGrades(in: context, gym: "Ostbloc")
+
+        XCTAssertEqual(grades, ["V3", "V5"])
+    }
+
+    @MainActor
+    func testMatchingCountUsesExactGymAndGrade() {
+        makeClimb(gym: "Ostbloc", grade: "V4")
+        makeClimb(gym: "Ostbloc", grade: "V4")
+        makeClimb(gym: "ostbloc", grade: "V4")
+        makeClimb(gym: "Ostbloc", grade: "v4")
+
+        let count = GradeMigrationService.matchingCount(in: context, gym: "Ostbloc", oldGrade: "V4")
+
+        XCTAssertEqual(count, 2)
+    }
+
+    @MainActor
+    @discardableResult
+    private func makeClimb(
+        gym: String,
+        grade: String,
+        feelsLikeGrade: String? = nil
+    ) -> ClimbEntry {
+        let climb = ClimbEntry(
+            climbType: .boulder,
+            grade: grade,
+            feelsLikeGrade: feelsLikeGrade,
+            style: "Technical",
+            attempts: "1",
+            gym: gym
+        )
+        context.insert(climb)
+        return climb
+    }
+}

--- a/ClimbingProgramTests/GradeMigrationServiceTests.swift
+++ b/ClimbingProgramTests/GradeMigrationServiceTests.swift
@@ -80,6 +80,111 @@ final class GradeMigrationServiceTests: ClimbingProgramTestSuite {
     }
 
     @MainActor
+    func testBulkMigrationUsesOriginalGradesAndDoesNotCascade() throws {
+        let originalFour = makeClimb(gym: "Ostbloc", grade: "4")
+        let originalFive = makeClimb(gym: "Ostbloc", grade: "5")
+        let otherGymFour = makeClimb(gym: "Bouldergarten", grade: "4")
+
+        let summary = try GradeMigrationService.migrateAll(
+            in: context,
+            gym: "Ostbloc",
+            mappings: [
+                .init(oldGrade: "4", newGrade: "5", newFeelsLikeGrade: nil),
+                .init(oldGrade: "5", newGrade: "6", newFeelsLikeGrade: nil)
+            ]
+        )
+
+        XCTAssertEqual(summary.count, 2)
+        XCTAssertEqual(originalFour.grade, "5")
+        XCTAssertEqual(originalFive.grade, "6")
+        XCTAssertEqual(otherGymFour.grade, "4")
+        XCTAssertEqual(
+            summary.rows,
+            [
+                .init(oldGrade: "4", newGrade: "5", newFeelsLikeGrade: nil, count: 1),
+                .init(oldGrade: "5", newGrade: "6", newFeelsLikeGrade: nil, count: 1)
+            ]
+        )
+    }
+
+    @MainActor
+    func testBulkMigrationCanMapMultipleOldGradesToSameTargetGrade() throws {
+        let v4 = makeClimb(gym: "Ostbloc", grade: "V4")
+        let v5 = makeClimb(gym: "Ostbloc", grade: "V5")
+
+        let summary = try GradeMigrationService.migrateAll(
+            in: context,
+            gym: "Ostbloc",
+            mappings: [
+                .init(oldGrade: "V4", newGrade: "V6", newFeelsLikeGrade: nil),
+                .init(oldGrade: "V5", newGrade: "V6", newFeelsLikeGrade: nil)
+            ]
+        )
+
+        XCTAssertEqual(summary.count, 2)
+        XCTAssertEqual(v4.grade, "V6")
+        XCTAssertEqual(v5.grade, "V6")
+    }
+
+    @MainActor
+    func testBulkMigrationLeavesUnmappedGradesUnchanged() throws {
+        let mapped = makeClimb(gym: "Ostbloc", grade: "V4", feelsLikeGrade: "V5")
+        let unmapped = makeClimb(gym: "Ostbloc", grade: "V5", feelsLikeGrade: "V6")
+
+        let summary = try GradeMigrationService.migrateAll(
+            in: context,
+            gym: "Ostbloc",
+            mappings: [
+                .init(oldGrade: "V4", newGrade: "V6", newFeelsLikeGrade: "V7")
+            ]
+        )
+
+        XCTAssertEqual(summary.count, 1)
+        XCTAssertEqual(mapped.grade, "V6")
+        XCTAssertEqual(mapped.feelsLikeGrade, "V7")
+        XCTAssertEqual(unmapped.grade, "V5")
+        XCTAssertEqual(unmapped.feelsLikeGrade, "V6")
+    }
+
+    @MainActor
+    func testBulkMigrationIgnoresBlankTargetsAndNoOpMappings() throws {
+        let noTarget = makeClimb(gym: "Ostbloc", grade: "V4", feelsLikeGrade: "V5")
+        let noChange = makeClimb(gym: "Ostbloc", grade: "V5", feelsLikeGrade: "V6")
+
+        let summary = try GradeMigrationService.migrateAll(
+            in: context,
+            gym: "Ostbloc",
+            mappings: [
+                .init(oldGrade: "V4", newGrade: " ", newFeelsLikeGrade: nil),
+                .init(oldGrade: "V5", newGrade: "V5", newFeelsLikeGrade: " ")
+            ]
+        )
+
+        XCTAssertEqual(summary.count, 0)
+        XCTAssertEqual(noTarget.grade, "V4")
+        XCTAssertEqual(noTarget.feelsLikeGrade, "V5")
+        XCTAssertEqual(noChange.grade, "V5")
+        XCTAssertEqual(noChange.feelsLikeGrade, "V6")
+    }
+
+    @MainActor
+    func testBulkMigrationAllowsFeelsLikeOnlyForSameGrade() throws {
+        let climb = makeClimb(gym: "Ostbloc", grade: "V5", feelsLikeGrade: "V6")
+
+        let summary = try GradeMigrationService.migrateAll(
+            in: context,
+            gym: "Ostbloc",
+            mappings: [
+                .init(oldGrade: "V5", newGrade: "V5", newFeelsLikeGrade: "V7")
+            ]
+        )
+
+        XCTAssertEqual(summary.count, 1)
+        XCTAssertEqual(climb.grade, "V5")
+        XCTAssertEqual(climb.feelsLikeGrade, "V7")
+    }
+
+    @MainActor
     func testAvailableOldGradesReturnsDistinctSortedGradesForSelectedGym() {
         makeClimb(gym: "Ostbloc", grade: "V5")
         makeClimb(gym: "Ostbloc", grade: "V3")
@@ -89,6 +194,24 @@ final class GradeMigrationServiceTests: ClimbingProgramTestSuite {
         let grades = GradeMigrationService.availableOldGrades(in: context, gym: "Ostbloc")
 
         XCTAssertEqual(grades, ["V3", "V5"])
+    }
+
+    @MainActor
+    func testGradeCountsReturnsDistinctSortedGradesWithCountsForSelectedGym() {
+        makeClimb(gym: "Ostbloc", grade: "V5")
+        makeClimb(gym: "Ostbloc", grade: "V3")
+        makeClimb(gym: "Ostbloc", grade: "V5")
+        makeClimb(gym: "Bouldergarten", grade: "V1")
+
+        let counts = GradeMigrationService.gradeCounts(in: context, gym: "Ostbloc")
+
+        XCTAssertEqual(
+            counts,
+            [
+                .init(grade: "V3", count: 1),
+                .init(grade: "V5", count: 2)
+            ]
+        )
     }
 
     @MainActor

--- a/ClimbingProgramTests/GradeMigrationServiceTests.swift
+++ b/ClimbingProgramTests/GradeMigrationServiceTests.swift
@@ -14,52 +14,31 @@ final class GradeMigrationServiceTests: ClimbingProgramTestSuite {
             in: context,
             gym: "Ostbloc",
             oldGrade: "V4",
-            newGrade: "V6",
-            newFeelsLikeGrade: nil
+            newGrade: "V6"
         )
 
         XCTAssertEqual(summary.count, 2)
         XCTAssertEqual(matchingOne.grade, "V6")
+        XCTAssertEqual(matchingOne.feelsLikeGrade, "V5")
         XCTAssertEqual(matchingTwo.grade, "V6")
         XCTAssertEqual(sameGradeOtherGym.grade, "V4")
         XCTAssertEqual(otherGradeSameGym.grade, "V5")
     }
 
     @MainActor
-    func testMigrationUpdatesFeelsLikeGradeWhenProvided() throws {
+    func testMigrationLeavesFeelsLikeGradeUnchanged() throws {
         let climb = makeClimb(gym: "Ostbloc", grade: "6a", feelsLikeGrade: "6b")
 
         let summary = try GradeMigrationService.migrate(
             in: context,
             gym: "Ostbloc",
             oldGrade: "6a",
-            newGrade: "6c",
-            newFeelsLikeGrade: " 7a "
+            newGrade: "6c"
         )
 
         XCTAssertEqual(summary.count, 1)
         XCTAssertEqual(climb.grade, "6c")
-        XCTAssertEqual(climb.feelsLikeGrade, "7a")
-    }
-
-    @MainActor
-    func testMigrationLeavesFeelsLikeGradeUnchangedWhenBlank() throws {
-        let climbWithValue = makeClimb(gym: "Ostbloc", grade: "6a", feelsLikeGrade: "6b")
-        let climbWithoutValue = makeClimb(gym: "Ostbloc", grade: "6a", feelsLikeGrade: nil)
-
-        let summary = try GradeMigrationService.migrate(
-            in: context,
-            gym: "Ostbloc",
-            oldGrade: "6a",
-            newGrade: "6c",
-            newFeelsLikeGrade: " "
-        )
-
-        XCTAssertEqual(summary.count, 2)
-        XCTAssertEqual(climbWithValue.grade, "6c")
-        XCTAssertEqual(climbWithValue.feelsLikeGrade, "6b")
-        XCTAssertEqual(climbWithoutValue.grade, "6c")
-        XCTAssertNil(climbWithoutValue.feelsLikeGrade)
+        XCTAssertEqual(climb.feelsLikeGrade, "6b")
     }
 
     @MainActor
@@ -70,8 +49,7 @@ final class GradeMigrationServiceTests: ClimbingProgramTestSuite {
             in: context,
             gym: "Ostbloc",
             oldGrade: "V3",
-            newGrade: "V5",
-            newFeelsLikeGrade: "V6"
+            newGrade: "V5"
         )
 
         XCTAssertEqual(summary.count, 0)
@@ -89,8 +67,8 @@ final class GradeMigrationServiceTests: ClimbingProgramTestSuite {
             in: context,
             gym: "Ostbloc",
             mappings: [
-                .init(oldGrade: "4", newGrade: "5", newFeelsLikeGrade: nil),
-                .init(oldGrade: "5", newGrade: "6", newFeelsLikeGrade: nil)
+                .init(oldGrade: "4", newGrade: "5"),
+                .init(oldGrade: "5", newGrade: "6")
             ]
         )
 
@@ -101,8 +79,8 @@ final class GradeMigrationServiceTests: ClimbingProgramTestSuite {
         XCTAssertEqual(
             summary.rows,
             [
-                .init(oldGrade: "4", newGrade: "5", newFeelsLikeGrade: nil, count: 1),
-                .init(oldGrade: "5", newGrade: "6", newFeelsLikeGrade: nil, count: 1)
+                .init(oldGrade: "4", newGrade: "5", count: 1),
+                .init(oldGrade: "5", newGrade: "6", count: 1)
             ]
         )
     }
@@ -116,8 +94,8 @@ final class GradeMigrationServiceTests: ClimbingProgramTestSuite {
             in: context,
             gym: "Ostbloc",
             mappings: [
-                .init(oldGrade: "V4", newGrade: "V6", newFeelsLikeGrade: nil),
-                .init(oldGrade: "V5", newGrade: "V6", newFeelsLikeGrade: nil)
+                .init(oldGrade: "V4", newGrade: "V6"),
+                .init(oldGrade: "V5", newGrade: "V6")
             ]
         )
 
@@ -135,13 +113,13 @@ final class GradeMigrationServiceTests: ClimbingProgramTestSuite {
             in: context,
             gym: "Ostbloc",
             mappings: [
-                .init(oldGrade: "V4", newGrade: "V6", newFeelsLikeGrade: "V7")
+                .init(oldGrade: "V4", newGrade: "V6")
             ]
         )
 
         XCTAssertEqual(summary.count, 1)
         XCTAssertEqual(mapped.grade, "V6")
-        XCTAssertEqual(mapped.feelsLikeGrade, "V7")
+        XCTAssertEqual(mapped.feelsLikeGrade, "V5")
         XCTAssertEqual(unmapped.grade, "V5")
         XCTAssertEqual(unmapped.feelsLikeGrade, "V6")
     }
@@ -155,8 +133,8 @@ final class GradeMigrationServiceTests: ClimbingProgramTestSuite {
             in: context,
             gym: "Ostbloc",
             mappings: [
-                .init(oldGrade: "V4", newGrade: " ", newFeelsLikeGrade: nil),
-                .init(oldGrade: "V5", newGrade: "V5", newFeelsLikeGrade: " ")
+                .init(oldGrade: "V4", newGrade: " "),
+                .init(oldGrade: "V5", newGrade: "V5")
             ]
         )
 
@@ -165,23 +143,6 @@ final class GradeMigrationServiceTests: ClimbingProgramTestSuite {
         XCTAssertEqual(noTarget.feelsLikeGrade, "V5")
         XCTAssertEqual(noChange.grade, "V5")
         XCTAssertEqual(noChange.feelsLikeGrade, "V6")
-    }
-
-    @MainActor
-    func testBulkMigrationAllowsFeelsLikeOnlyForSameGrade() throws {
-        let climb = makeClimb(gym: "Ostbloc", grade: "V5", feelsLikeGrade: "V6")
-
-        let summary = try GradeMigrationService.migrateAll(
-            in: context,
-            gym: "Ostbloc",
-            mappings: [
-                .init(oldGrade: "V5", newGrade: "V5", newFeelsLikeGrade: "V7")
-            ]
-        )
-
-        XCTAssertEqual(summary.count, 1)
-        XCTAssertEqual(climb.grade, "V5")
-        XCTAssertEqual(climb.feelsLikeGrade, "V7")
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- Add a Settings entry for migrating logged grades by gym
- Add a SwiftData-backed grade migration service with optional My Grade updates
- Add unit coverage for exact matching, feels-like behavior, no-match behavior, and old-grade options

## Tests
- xcodebuild test -project ClimbingProgram.xcodeproj -scheme ClimbingProgramTests -destination 'platform=iOS Simulator,name=iPhone 17'