### PR TITLE
Fix minor sync and plan ordering issues

### DIFF
--- a/ClimbingProgram/features/climb/BoardSyncShared.swift
+++ b/ClimbingProgram/features/climb/BoardSyncShared.swift
@@ -118,6 +118,34 @@ enum BoardDateParser {
     static let f9 = makeFormatter("yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX")
     static let f10 = makeFormatter("yyyy-MM-dd'T'HH:mm:ssXXXXX")
 
+    /// Tension Board returns some `climbed_at` values without an offset. Those values
+    /// represent the time the climber recorded locally, rather than a UTC timestamp.
+    /// Parse only those offset-less values in the device timezone; timestamps that
+    /// include an offset retain their original absolute instant.
+    static func parseTensionClimbedAt(_ value: String?, timeZone: TimeZone = .current) -> Date? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
+            return nil
+        }
+
+        guard !hasExplicitTimeZone(value) else {
+            return parse(value)
+        }
+
+        for format in [
+            "yyyy-MM-dd HH:mm:ss.SSSSSS",
+            "yyyy-MM-dd HH:mm:ss",
+            "yyyy-MM-dd'T'HH:mm:ss.SSSSSS",
+            "yyyy-MM-dd'T'HH:mm:ss"
+        ] {
+            let formatter = makeFormatter(format, timeZone: timeZone)
+            if let date = formatter.date(from: value) {
+                return date
+            }
+        }
+
+        return nil
+    }
+
     static func parse(_ s: String?) -> Date? {
         guard var s = s?.trimmingCharacters(in: .whitespacesAndNewlines), !s.isEmpty else { return nil }
 
@@ -141,6 +169,20 @@ enum BoardDateParser {
             }
         }
         return nil
+    }
+
+    private static func makeFormatter(_ format: String, timeZone: TimeZone) -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = timeZone
+        formatter.dateFormat = format
+        return formatter
+    }
+
+    private static func hasExplicitTimeZone(_ value: String) -> Bool {
+        value.hasSuffix("Z") ||
+        value.hasSuffix(" UTC") ||
+        value.range(of: #"[+-]\d{2}:?\d{2}$"#, options: .regularExpression) != nil
     }
 }
 

--- a/ClimbingProgram/features/climb/TB2SyncManager.swift
+++ b/ClimbingProgram/features/climb/TB2SyncManager.swift
@@ -56,7 +56,7 @@ enum TB2SyncManager {
         
         for b in bids {
             guard let uuid = b.climbUUID else { continue }
-            guard let date = BoardDateParser.parse(b.climbedAt) else { continue } // strict: no fallback to now
+            guard let date = BoardDateParser.parseTensionClimbedAt(b.climbedAt) else { continue } // strict: no fallback to now
             let day = date
             let key = BidKey(uuid: uuid, day: day, angle: b.angle, isMirror: b.isMirror)
             var sum = bidSummary[key] ?? BidSum(tries: 0, comment: nil)
@@ -93,7 +93,7 @@ enum TB2SyncManager {
             let disp = dispNum ?? loggedNum
             let loggedGrade = BoardGradeMapper.grade(of: loggedNum)
             let displayedGrade = BoardGradeMapper.grade(of: disp)
-            guard let date = BoardDateParser.parse(a.climbedAt) else { continue }
+            guard let date = BoardDateParser.parseTensionClimbedAt(a.climbedAt) else { continue }
             let day = date
             let tries = (a.bidCount ?? a.attemptID ?? 1)
             let key = BidKey(uuid: uuid ?? "", day: day, angle: angle, isMirror: a.isMirror)

--- a/ClimbingProgram/features/plans/PlanDayExerciseOrdering.swift
+++ b/ClimbingProgram/features/plans/PlanDayExerciseOrdering.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+enum PlanDayExerciseOrdering {
+    static func sortedNames(
+        _ names: [String],
+        manualOrder: [String: Int],
+        catalogOrder: [String: Int],
+        isQuickLogged: (String) -> Bool
+    ) -> [String] {
+        names.sorted { first, second in
+            let firstManualOrder = manualOrder[first]
+            let secondManualOrder = manualOrder[second]
+
+            if let firstManualOrder, let secondManualOrder, firstManualOrder != secondManualOrder {
+                return firstManualOrder < secondManualOrder
+            }
+
+            if firstManualOrder != nil, secondManualOrder == nil {
+                return true
+            }
+            if firstManualOrder == nil, secondManualOrder != nil {
+                return false
+            }
+
+            let firstIsQuickLogged = isQuickLogged(first)
+            let secondIsQuickLogged = isQuickLogged(second)
+            if firstIsQuickLogged != secondIsQuickLogged {
+                return !firstIsQuickLogged
+            }
+
+            let firstCatalogOrder = catalogOrder[first] ?? .max
+            let secondCatalogOrder = catalogOrder[second] ?? .max
+            if firstCatalogOrder != secondCatalogOrder {
+                return firstCatalogOrder < secondCatalogOrder
+            }
+
+            return first.localizedStandardCompare(second) == .orderedAscending
+        }
+    }
+}

--- a/ClimbingProgram/features/plans/PlansViews.swift
+++ b/ClimbingProgram/features/plans/PlansViews.swift
@@ -854,21 +854,12 @@ struct PlanDayEditor: View {
             }
         }
         
-        // Sort chosen exercises: not quick-logged first (by catalog order), then quick-logged at bottom
-        return day.chosenExercises.sorted { name1, name2 in
-            let isLogged1 = isExerciseQuickLogged(name: name1)
-            let isLogged2 = isExerciseQuickLogged(name: name2)
-            
-            // If one is logged and the other isn't, put the unlogged one first
-            if isLogged1 != isLogged2 {
-                return !isLogged1 // not logged (false) comes before logged (true)
-            }
-            
-            // If both have the same logged status, sort by catalog order
-            let order1 = exerciseOrderMap[name1] ?? Int.max
-            let order2 = exerciseOrderMap[name2] ?? Int.max
-            return order1 < order2
-        }
+        return PlanDayExerciseOrdering.sortedNames(
+            day.chosenExercises,
+            manualOrder: day.exerciseOrder,
+            catalogOrder: exerciseOrderMap,
+            isQuickLogged: isExerciseQuickLogged
+        )
     }
 
     // Helper to get exercises grouped by activity type

--- a/ClimbingProgram/features/timer/TimerViews.swift
+++ b/ClimbingProgram/features/timer/TimerViews.swift
@@ -74,12 +74,7 @@ struct TimerView: View {
                                     sheetRoute = .customTimer
                                 }
                             }
-                            
-                            Section("Template Management") {
-                                Button("All Templates", systemImage: "folder") {
-                                    sheetRoute = .allTemplates
-                                }
-                            }
+
                         } label: {
                             Image(systemName: "ellipsis.circle")
                                 .font(.title3)

--- a/ClimbingProgramTests/BoardDateParserTests.swift
+++ b/ClimbingProgramTests/BoardDateParserTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+import XCTest
+
+@testable import klettrack
+
+final class BoardDateParserTests: XCTestCase {
+    func testTensionZoneLessTimestampUsesTheClimberTimezone() throws {
+        let berlin = try XCTUnwrap(TimeZone(identifier: "Europe/Berlin"))
+
+        let date = try XCTUnwrap(
+            BoardDateParser.parseTensionClimbedAt(
+                "2026-06-02 22:02:00.000000",
+                timeZone: berlin
+            )
+        )
+
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = berlin
+        let components = calendar.dateComponents([.year, .month, .day, .hour, .minute], from: date)
+
+        XCTAssertEqual(components.year, 2026)
+        XCTAssertEqual(components.month, 6)
+        XCTAssertEqual(components.day, 2)
+        XCTAssertEqual(components.hour, 22)
+        XCTAssertEqual(components.minute, 2)
+    }
+
+    func testTensionTimestampWithUTCOffsetPreservesItsAbsoluteInstant() throws {
+        let berlin = try XCTUnwrap(TimeZone(identifier: "Europe/Berlin"))
+        let expected = try XCTUnwrap(BoardDateParser.parse("2026-06-02T20:02:00Z"))
+        let actual = try XCTUnwrap(
+            BoardDateParser.parseTensionClimbedAt(
+                "2026-06-02T20:02:00Z",
+                timeZone: berlin
+            )
+        )
+
+        XCTAssertEqual(actual, expected)
+    }
+}

--- a/ClimbingProgramTests/PlanDayExerciseOrderingTests.swift
+++ b/ClimbingProgramTests/PlanDayExerciseOrderingTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+
+@testable import klettrack
+
+final class PlanDayExerciseOrderingTests: XCTestCase {
+    func testManualOrderOverridesCatalogOrderAfterReload() {
+        let ordered = PlanDayExerciseOrdering.sortedNames(
+            ["Hangboard", "Pull-ups", "Push-ups"],
+            manualOrder: ["Push-ups": 0, "Hangboard": 1, "Pull-ups": 2],
+            catalogOrder: ["Hangboard": 0, "Pull-ups": 1, "Push-ups": 2],
+            isQuickLogged: { _ in false }
+        )
+
+        XCTAssertEqual(ordered, ["Push-ups", "Hangboard", "Pull-ups"])
+    }
+
+    func testCatalogOrderIsUsedWhenNoManualOrderExists() {
+        let ordered = PlanDayExerciseOrdering.sortedNames(
+            ["Push-ups", "Hangboard", "Pull-ups"],
+            manualOrder: [:],
+            catalogOrder: ["Hangboard": 0, "Pull-ups": 1, "Push-ups": 2],
+            isQuickLogged: { _ in false }
+        )
+
+        XCTAssertEqual(ordered, ["Hangboard", "Pull-ups", "Push-ups"])
+    }
+}


### PR DESCRIPTION
## Summary
- parse offset-less Tension Board timestamps in the local timezone
- preserve manually reordered PlanDay exercises after navigation
- remove the extra timer template button

## Validation
- targeted unit tests for board date parsing and PlanDay exercise ordering