### PR TITLE
Add shared day notes and tags

### DIFF
--- a/ClimbingProgram/app/ClimbingProgramApp.swift
+++ b/ClimbingProgram/app/ClimbingProgramApp.swift
@@ -19,6 +19,7 @@ struct ClimbingProgramApp: App {
         .modelContainer(for: [
             Activity.self, TrainingType.self, Exercise.self,
             Session.self, SessionItem.self,
+            DayLog.self, DayTag.self,
             Plan.self, PlanDay.self,
             TimerTemplate.self, TimerInterval.self, TimerSession.self, TimerLap.self,
             ClimbEntry.self, ClimbStyle.self, ClimbGym.self, ClimbMedia.self,

--- a/ClimbingProgram/app/RootTabView.swift
+++ b/ClimbingProgram/app/RootTabView.swift
@@ -161,6 +161,9 @@ struct RootTabView: View {
             runOnce(per: "climb_attempts_default_backfill_2026-06-02") {
                 backfillClimbEntryAttempts(context)
             }
+            runOnce(per: "day_log_plan_notes_backfill_2026-07-27") {
+                backfillDayLogsFromPlanDayNotes(context)
+            }
             runOnce(per: "daytypedefaultflags_backfill_2025-11-08") {
                 backfillDefaultFlags(context)
             }

--- a/ClimbingProgram/data/migrations/DayLogBackfill.swift
+++ b/ClimbingProgram/data/migrations/DayLogBackfill.swift
@@ -1,0 +1,31 @@
+//
+//  DayLogBackfill.swift
+//  klettrack
+//
+
+import Foundation
+import SwiftData
+
+@MainActor
+func backfillDayLogsFromPlanDayNotes(_ context: ModelContext) {
+    do {
+        let planDays = try context.fetch(
+            FetchDescriptor<PlanDay>(sortBy: [SortDescriptor(\.date, order: .forward)])
+        )
+
+        for planDay in planDays {
+            guard let legacyNote = planDay.dailyNotes?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !legacyNote.isEmpty
+            else { continue }
+
+            guard let dayLog = DayLogStore.dayLog(for: planDay.date, in: context) else { continue }
+            if dayLog.note?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty != false {
+                dayLog.note = legacyNote
+            }
+        }
+
+        try context.save()
+    } catch {
+        print("backfillDayLogsFromPlanDayNotes failed: \(error.localizedDescription)")
+    }
+}

--- a/ClimbingProgram/data/models/Models.swift
+++ b/ClimbingProgram/data/models/Models.swift
@@ -148,6 +148,48 @@ final class SessionItem {
     }
 }
 
+@Model
+final class DayLog {
+    var id: UUID = UUID()
+    var date: Date = Date()
+    var note: String?
+    @Relationship(deleteRule: .nullify)
+    var tags: [DayTag]?
+
+    init(id: UUID = UUID(), date: Date = Date(), note: String? = nil, tags: [DayTag]? = nil) {
+        self.id = id
+        self.date = Calendar.current.startOfDay(for: date)
+        self.note = note
+        self.tags = tags
+    }
+}
+
+@Model
+final class DayTag {
+    var id: UUID = UUID()
+    var name: String = ""
+    var colorKey: String = "gray"
+    var sort: Int = 0
+    var isHidden: Bool = false
+    var createdAt: Date = Date()
+
+    init(
+        id: UUID = UUID(),
+        name: String = "",
+        colorKey: String = "gray",
+        sort: Int = 0,
+        isHidden: Bool = false,
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.name = name
+        self.colorKey = DayTypeModel.allowedColorKeys.contains(colorKey) ? colorKey : "gray"
+        self.sort = sort
+        self.isHidden = isHidden
+        self.createdAt = createdAt
+    }
+}
+
 // MARK: - Timer Models
 
 @Model
@@ -293,4 +335,3 @@ final class TimerLap {
         self.notes = notes
     }
 }
-

--- a/ClimbingProgram/data/models/Models.swift
+++ b/ClimbingProgram/data/models/Models.swift
@@ -153,7 +153,7 @@ final class DayLog {
     var id: UUID = UUID()
     var date: Date = Date()
     var note: String?
-    @Relationship(deleteRule: .nullify)
+    @Relationship(deleteRule: .nullify, inverse: \DayTag.dayLogs)
     var tags: [DayTag]?
 
     init(id: UUID = UUID(), date: Date = Date(), note: String? = nil, tags: [DayTag]? = nil) {
@@ -172,6 +172,7 @@ final class DayTag {
     var sort: Int = 0
     var isHidden: Bool = false
     var createdAt: Date = Date()
+    var dayLogs: [DayLog]?
 
     init(
         id: UUID = UUID(),
@@ -179,7 +180,8 @@ final class DayTag {
         colorKey: String = "gray",
         sort: Int = 0,
         isHidden: Bool = false,
-        createdAt: Date = Date()
+        createdAt: Date = Date(),
+        dayLogs: [DayLog]? = nil
     ) {
         self.id = id
         self.name = name
@@ -187,6 +189,7 @@ final class DayTag {
         self.sort = sort
         self.isHidden = isHidden
         self.createdAt = createdAt
+        self.dayLogs = dayLogs
     }
 }
 

--- a/ClimbingProgram/data/persistence/DayLogStore.swift
+++ b/ClimbingProgram/data/persistence/DayLogStore.swift
@@ -1,0 +1,127 @@
+//
+//  DayLogStore.swift
+//  klettrack
+//
+
+import Foundation
+import SwiftData
+
+@MainActor
+enum DayLogStore {
+    static func normalizedDay(_ date: Date, calendar: Calendar = .current) -> Date {
+        calendar.startOfDay(for: date)
+    }
+
+    static func activeTags(from dayLog: DayLog?) -> [DayTag] {
+        (dayLog?.tags ?? [])
+            .filter { !$0.isHidden }
+            .sorted { lhs, rhs in
+                if lhs.sort != rhs.sort { return lhs.sort < rhs.sort }
+                return lhs.name.localizedStandardCompare(rhs.name) == .orderedAscending
+            }
+    }
+
+    static func hasContext(_ dayLog: DayLog?) -> Bool {
+        guard let dayLog else { return false }
+        let hasNote = dayLog.note?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+        return hasNote || !activeTags(from: dayLog).isEmpty
+    }
+
+    static func fetchDayLog(for date: Date, in context: ModelContext) -> DayLog? {
+        let day = normalizedDay(date)
+        let nextDay = Calendar.current.date(byAdding: .day, value: 1, to: day) ?? day
+        let descriptor = FetchDescriptor<DayLog>(
+            predicate: #Predicate<DayLog> { log in
+                log.date >= day && log.date < nextDay
+            },
+            sortBy: [SortDescriptor(\.date)]
+        )
+        return (try? context.fetch(descriptor))?.first
+    }
+
+    @discardableResult
+    static func dayLog(for date: Date, in context: ModelContext, createIfMissing: Bool = true) -> DayLog? {
+        if let existing = fetchDayLog(for: date, in: context) {
+            return existing
+        }
+        guard createIfMissing else { return nil }
+        let created = DayLog(date: normalizedDay(date))
+        context.insert(created)
+        return created
+    }
+
+    static func setNote(_ rawNote: String, for dayLog: DayLog) {
+        let trimmed = rawNote.trimmingCharacters(in: .whitespacesAndNewlines)
+        dayLog.note = trimmed.isEmpty ? nil : trimmed
+    }
+
+    static func activeTag(named rawName: String, in context: ModelContext, excluding id: UUID? = nil) -> DayTag? {
+        let normalizedName = rawName.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !normalizedName.isEmpty else { return nil }
+        let tags = (try? context.fetch(FetchDescriptor<DayTag>())) ?? []
+        return tags.first {
+            !$0.isHidden &&
+            $0.id != id &&
+            $0.name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == normalizedName
+        }
+    }
+
+    @discardableResult
+    static func createTag(name rawName: String, colorKey: String, in context: ModelContext) -> DayTag? {
+        let name = rawName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else { return nil }
+        if let existing = activeTag(named: name, in: context) {
+            return existing
+        }
+        let allTags = (try? context.fetch(FetchDescriptor<DayTag>())) ?? []
+        if let hidden = allTags.first(where: {
+            $0.isHidden &&
+            $0.name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == name.lowercased()
+        }) {
+            hidden.name = name
+            hidden.colorKey = DayTypeModel.allowedColorKeys.contains(colorKey) ? colorKey : "gray"
+            hidden.isHidden = false
+            return hidden
+        }
+        let tag = DayTag(
+            name: name,
+            colorKey: colorKey,
+            sort: ((allTags.map(\.sort).max() ?? -10) + 10)
+        )
+        context.insert(tag)
+        return tag
+    }
+
+    static func renameTag(_ tag: DayTag, to rawName: String, colorKey: String, in context: ModelContext) -> Bool {
+        let name = rawName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else { return false }
+        guard activeTag(named: name, in: context, excluding: tag.id) == nil else { return false }
+        tag.name = name
+        if DayTypeModel.allowedColorKeys.contains(colorKey) {
+            tag.colorKey = colorKey
+        }
+        return true
+    }
+
+    static func setTag(_ tag: DayTag, assigned isAssigned: Bool, to dayLog: DayLog) {
+        var tags = dayLog.tags ?? []
+        if isAssigned {
+            if !tags.contains(where: { $0.id == tag.id }) {
+                tags.append(tag)
+            }
+        } else {
+            tags.removeAll { $0.id == tag.id }
+        }
+        dayLog.tags = tags
+    }
+
+    static func hideTag(_ tag: DayTag, in context: ModelContext) {
+        tag.isHidden = true
+        let dayLogs = (try? context.fetch(FetchDescriptor<DayLog>())) ?? []
+        for dayLog in dayLogs {
+            var tags = dayLog.tags ?? []
+            tags.removeAll { $0.id == tag.id }
+            dayLog.tags = tags
+        }
+    }
+}

--- a/ClimbingProgram/features/climb/ClimbMetaManagerView.swift
+++ b/ClimbingProgram/features/climb/ClimbMetaManagerView.swift
@@ -11,6 +11,7 @@ struct ClimbMetaManagerView: View {
         case style
         case gym
         case day
+        case dayTag
 
         var id: String { rawValue }
     }
@@ -29,6 +30,13 @@ struct ClimbMetaManagerView: View {
         filter: #Predicate<DayTypeModel> { $0.isHidden == false },
         sort: [SortDescriptor(\DayTypeModel.name, order: .forward)]
     ) private var days: [DayTypeModel]
+    @Query(
+        filter: #Predicate<DayTag> { $0.isHidden == false },
+        sort: [
+            SortDescriptor<DayTag>(\DayTag.sort, order: .forward),
+            SortDescriptor<DayTag>(\DayTag.name, order: .forward)
+        ]
+    ) private var dayTags: [DayTag]
     
     // Add / rename state
     @State private var addRoute: AddRoute? = nil
@@ -36,10 +44,12 @@ struct ClimbMetaManagerView: View {
     @State private var styleDraft = ""
     @State private var gymDraft = ""
     @State private var dayDraft = ""
+    @State private var dayTagDraft = ""
 
     @State private var renamingStyle: ClimbStyle? = nil
     @State private var renamingGym: ClimbGym? = nil
     @State private var renamingDay: DayTypeModel? = nil
+    @State private var renamingDayTag: DayTag? = nil
     @State private var renameDraft = ""
 
     // Restore/Add defaults state
@@ -64,12 +74,18 @@ struct ClimbMetaManagerView: View {
     private var mainList: some View {
         List {
             daysSection
+            dayTagsSection
             stylesSection
             gymsSection
         }
         .navigationTitle("Data Manager")
         .navigationBarTitleDisplayMode(.large)
         .toolbar { trailingMenu }
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                EditButton()
+            }
+        }
         .sheet(item: $addRoute) { route in
             switch route {
             case .style:
@@ -94,6 +110,14 @@ struct ClimbMetaManagerView: View {
                     initialColorKey: "gray"
                 ) { newName, newColorKey in
                     handleAddDay(newName: newName, newColorKey: newColorKey)
+                }
+            case .dayTag:
+                DayTagEditSheet(
+                    title: "New Day Tag",
+                    initialName: "",
+                    initialColorKey: "gray"
+                ) { newName, newColorKey in
+                    handleAddDayTag(newName: newName, newColorKey: newColorKey)
                 }
             }
         }
@@ -126,6 +150,16 @@ struct ClimbMetaManagerView: View {
                 handleRenameDay(day, newName: newName, newColorKey: newColorKey)
             }
         }
+        .sheet(item: $renamingDayTag) { tag in
+            DayTagEditSheet(
+                title: "Edit Day Tag",
+                initialName: tag.name,
+                initialColorKey: tag.colorKey
+            ) { newName, newColorKey in
+                handleRenameDayTag(tag, newName: newName, newColorKey: newColorKey)
+            }
+        }
+        .alert(item: $resultAlert, content: resultAlertView)
     }
     
     private var trailingMenu: some ToolbarContent {
@@ -141,6 +175,19 @@ struct ClimbMetaManagerView: View {
                 Image(systemName: "ellipsis.circle")
             }
         }
+    }
+
+    @MainActor
+    private func handleAddDayTag(newName: String, newColorKey: String) -> Bool {
+        let trimmed = newName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        guard DayLogStore.activeTag(named: trimmed, in: context) == nil else {
+            resultAlert = InfoAlert(message: "A day tag with this name already exists.")
+            return false
+        }
+        _ = DayLogStore.createTag(name: trimmed, colorKey: newColorKey, in: context)
+        try? context.save()
+        return true
     }
 
     
@@ -225,6 +272,21 @@ struct ClimbMetaManagerView: View {
         }
         try? context.save()
         return true
+    }
+
+    @MainActor
+    private func handleRenameDayTag(_ tag: DayTag, newName: String, newColorKey: String) -> Bool {
+        guard DayLogStore.renameTag(tag, to: newName, colorKey: newColorKey, in: context) else {
+            resultAlert = InfoAlert(message: "A day tag with this name already exists.")
+            return false
+        }
+        try? context.save()
+        return true
+    }
+
+    private func editDayTag(_ tag: DayTag) {
+        renameDraft = tag.name
+        renamingDayTag = tag
     }
 
     private func resultAlertView(_ info: InfoAlert) -> Alert {
@@ -348,6 +410,67 @@ struct ClimbMetaManagerView: View {
     }
 
     @ViewBuilder
+    private var dayTagsSection: some View {
+        Section {
+            if dayTags.isEmpty {
+                ContentUnavailableView(
+                    "No Day Tags",
+                    systemImage: "tag",
+                    description: Text("Add tags for calendar days")
+                )
+            } else {
+                ForEach(dayTags, id: \.id) { tag in
+                    Button {
+                        editDayTag(tag)
+                    } label: {
+                        DayTagManagerRow(tag: tag)
+                    }
+                    .buttonStyle(.plain)
+                        .contextMenu {
+                            Button {
+                                editDayTag(tag)
+                            } label: {
+                                Label("Edit", systemImage: "square.and.pencil")
+                            }
+                            Button(role: .destructive) {
+                                safeDeleteDayTag(tag)
+                            } label: {
+                                Label("Delete", systemImage: "trash")
+                            }
+                        }
+                        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                            Button {
+                                editDayTag(tag)
+                            } label: {
+                                Label("Edit", systemImage: "square.and.pencil")
+                            }
+                            .tint(.blue)
+
+                            Button(role: .destructive) {
+                                safeDeleteDayTag(tag)
+                            } label: {
+                                Label("Delete", systemImage: "trash")
+                            }
+                        }
+                }
+                .onMove(perform: moveDayTags)
+                .onDelete { (idx: IndexSet) in
+                    idx.map { dayTags[$0] }.forEach(safeDeleteDayTag(_:))
+                }
+            }
+
+            Button {
+                dayTagDraft = ""
+                addRoute = .dayTag
+            } label: {
+                Label("Add Day Tag", systemImage: "plus")
+            }
+        } header: {
+            Text("Day Tags")
+        }
+    }
+
+    @ViewBuilder
     private var gymsSection: some View {
         Section {
             if gyms.isEmpty {
@@ -435,6 +558,21 @@ struct ClimbMetaManagerView: View {
         }
     }
 
+    private struct DayTagManagerRow: View {
+        @Bindable var tag: DayTag
+
+        var body: some View {
+            HStack(spacing: 12) {
+                Circle()
+                    .fill(DayTypeModel.color(for: tag.colorKey).gradient)
+                    .frame(width: 12, height: 12)
+                Text(tag.name)
+                Spacer()
+            }
+            .contentShape(Rectangle())
+        }
+    }
+
     // MARK: - Deletes
     private func safeDeleteStyle(_ style: ClimbStyle) {
         style.isHidden = true
@@ -444,6 +582,21 @@ struct ClimbMetaManagerView: View {
     private func safeDeleteDay(_ day: DayTypeModel) {
         // Soft delete: hide instead of removing from the store
         day.isHidden = true
+        try? context.save()
+    }
+
+    @MainActor
+    private func safeDeleteDayTag(_ tag: DayTag) {
+        DayLogStore.hideTag(tag, in: context)
+        try? context.save()
+    }
+
+    private func moveDayTags(from source: IndexSet, to destination: Int) {
+        var working = dayTags
+        working.move(fromOffsets: source, toOffset: destination)
+        for (index, tag) in working.enumerated() {
+            tag.sort = index * 10
+        }
         try? context.save()
     }
 
@@ -506,7 +659,7 @@ struct ClimbMetaManagerView: View {
 
 #Preview {
     ClimbMetaManagerView()
-        .modelContainer(for: [ClimbStyle.self, ClimbGym.self, DayTypeModel.self], inMemory: true)
+        .modelContainer(for: [ClimbStyle.self, ClimbGym.self, DayTypeModel.self, DayLog.self, DayTag.self], inMemory: true)
 }
 
 // MARK: - Inline DayColorPickerSheet (kept in this file to satisfy the sheet reference)
@@ -600,6 +753,69 @@ private struct DayEditSheet: View {
                 Button("OK", role: .cancel) { }
             } message: {
                 Text("You cannot add a defulat value, use the recover function in the menu")
+            }
+        }
+        .presentationDetents([.medium, .large])
+    }
+}
+
+private struct DayTagEditSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let title: String
+    let onSave: (String, String) -> Bool
+
+    @State private var name: String
+    @State private var colorKey: String
+    @State private var showingAlert = false
+
+    init(title: String, initialName: String, initialColorKey: String, onSave: @escaping (String, String) -> Bool) {
+        self.title = title
+        self.onSave = onSave
+        _name = State(initialValue: initialName)
+        _colorKey = State(initialValue: initialColorKey)
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    HStack(spacing: 12) {
+                        Circle()
+                            .fill(DayTypeModel.color(for: colorKey).gradient)
+                            .frame(width: 16, height: 16)
+                        TextField("Tag name", text: $name)
+                            .textInputAutocapitalization(.words)
+                            .autocorrectionDisabled()
+                    }
+                    .padding(.vertical, 4)
+                } header: {
+                    Text("Tag")
+                }
+
+                Section("Pick a color") {
+                    ColorKeyPicker(selection: $colorKey)
+                }
+            }
+            .navigationTitle(title)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        let success = onSave(name, colorKey)
+                        if success {
+                            dismiss()
+                        } else {
+                            showingAlert = true
+                        }
+                    }
+                    .disabled(name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+            }
+            .alert("Unable to save tag", isPresented: $showingAlert) {
+                Button("OK", role: .cancel) { }
             }
         }
         .presentationDetents([.medium, .large])

--- a/ClimbingProgram/features/plans/PlansViews.swift
+++ b/ClimbingProgram/features/plans/PlansViews.swift
@@ -809,8 +809,7 @@ struct PlanDayEditor: View {
     @State private var showingClimbLog = false
     @State private var climbLoggingExercise: ExerciseSelection? = nil
     
-    // State for daily notes to handle the optional binding
-    @State private var dailyNotesText: String = ""
+    @State private var localDayLog: DayLog? = nil
     
     // Picker selection by identifier (prevents invalidated object binding)
     @State private var selectedDayTypeId: UUID? = nil
@@ -1261,20 +1260,11 @@ struct PlanDayEditor: View {
     // Break down daily notes section
     @ViewBuilder
     private var dailyNotesSection: some View {
-        Section ("Daily Notes") {
-            TextEditor(text: $dailyNotesText)
-                .frame(minHeight: 100)
-                .onAppear {
-                    // Initialize with the current value from the model
-                    dailyNotesText = day.dailyNotes ?? ""
-                }
-                .onChange(of: dailyNotesText) {
-                    // Save the notes to the model
-                    let trimmed = dailyNotesText.trimmingCharacters(in: .whitespacesAndNewlines)
-                    day.dailyNotes = trimmed.isEmpty ? nil : trimmed
-                    try? context.save()
-                }
-        }
+        DayContextEditorSection(
+            date: day.date,
+            dayLog: localDayLog,
+            onDayLogChanged: updateDayLog
+        )
     }
 
     var body: some View {
@@ -1303,6 +1293,12 @@ struct PlanDayEditor: View {
         }
         .navigationTitle(day.date.formatted(date: .abbreviated, time: .omitted))
         .listStyle(.insetGrouped)
+        .onAppear {
+            refreshDayLog()
+        }
+        .onChange(of: day.date) {
+            refreshDayLog()
+        }
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 HStack(spacing: 10) {
@@ -1712,6 +1708,14 @@ struct PlanDayEditor: View {
                     .lineLimit(1...3)
             }
         }
+    }
+
+    private func refreshDayLog() {
+        localDayLog = DayLogStore.fetchDayLog(for: day.date, in: context)
+    }
+
+    private func updateDayLog(_ dayLog: DayLog?) {
+        localDayLog = dayLog
     }
 }
 

--- a/ClimbingProgram/features/sessions/LogDaySummaryBuilder.swift
+++ b/ClimbingProgram/features/sessions/LogDaySummaryBuilder.swift
@@ -52,3 +52,60 @@ enum LogDaySummaryBuilder {
         return grouped
     }
 }
+
+@MainActor
+enum LogDaySummaryFilter {
+    static func filteredSummaries(
+        _ summaries: [Date: LogDaySummary],
+        dateRange: DateRange,
+        selectedTagIDs: Set<UUID>,
+        calendar: Calendar = .current
+    ) -> [Date: LogDaySummary] {
+        summaries.filter { date, summary in
+            matchesDate(date, dateRange: dateRange, calendar: calendar) &&
+            matchesTags(summary, selectedTagIDs: selectedTagIDs)
+        }
+    }
+
+    static func isDateFilterActive(
+        dateRange: DateRange,
+        availableDates: [Date],
+        calendar: Calendar = .current
+    ) -> Bool {
+        guard !availableDates.isEmpty,
+              let customStart = dateRange.customStart,
+              let customEnd = dateRange.customEnd,
+              let minDate = availableDates.min(),
+              let maxDate = availableDates.max()
+        else {
+            return false
+        }
+
+        return !(
+            calendar.isDate(customStart, inSameDayAs: minDate) &&
+            calendar.isDate(customEnd, inSameDayAs: maxDate)
+        )
+    }
+
+    private static func matchesDate(_ date: Date, dateRange: DateRange, calendar: Calendar) -> Bool {
+        let day = calendar.startOfDay(for: date)
+
+        if let customStart = dateRange.customStart {
+            let start = calendar.startOfDay(for: customStart)
+            if day < start { return false }
+        }
+
+        if let customEnd = dateRange.customEnd {
+            let end = calendar.startOfDay(for: customEnd)
+            if day > end { return false }
+        }
+
+        return true
+    }
+
+    private static func matchesTags(_ summary: LogDaySummary, selectedTagIDs: Set<UUID>) -> Bool {
+        guard !selectedTagIDs.isEmpty else { return true }
+        let dayTagIDs = Set(DayLogStore.activeTags(from: summary.dayLog).map(\.id))
+        return !dayTagIDs.isDisjoint(with: selectedTagIDs)
+    }
+}

--- a/ClimbingProgram/features/sessions/LogDaySummaryBuilder.swift
+++ b/ClimbingProgram/features/sessions/LogDaySummaryBuilder.swift
@@ -1,0 +1,54 @@
+//
+//  LogDaySummaryBuilder.swift
+//  klettrack
+//
+
+import Foundation
+
+struct LogDaySummary {
+    var exercises: Int = 0
+    var climbs: Int = 0
+    var session: Session?
+    var climbEntries: [ClimbEntry] = []
+    var dayLog: DayLog?
+}
+
+@MainActor
+enum LogDaySummaryBuilder {
+    static func build(
+        sessions: [Session],
+        climbEntries: [ClimbEntry],
+        dayLogs: [DayLog],
+        calendar: Calendar = .current
+    ) -> [Date: LogDaySummary] {
+        var grouped: [Date: LogDaySummary] = [:]
+
+        for session in sessions {
+            let dateKey = calendar.startOfDay(for: session.date)
+            if grouped[dateKey] == nil {
+                grouped[dateKey] = LogDaySummary()
+            }
+            grouped[dateKey]?.exercises = Array(session.items).count
+            grouped[dateKey]?.session = session
+        }
+
+        for climb in climbEntries {
+            let dateKey = calendar.startOfDay(for: climb.dateLogged)
+            if grouped[dateKey] == nil {
+                grouped[dateKey] = LogDaySummary()
+            }
+            grouped[dateKey]?.climbs += 1
+            grouped[dateKey]?.climbEntries.append(climb)
+        }
+
+        for dayLog in dayLogs where DayLogStore.hasContext(dayLog) {
+            let dateKey = calendar.startOfDay(for: dayLog.date)
+            if grouped[dateKey] == nil {
+                grouped[dateKey] = LogDaySummary()
+            }
+            grouped[dateKey]?.dayLog = dayLog
+        }
+
+        return grouped
+    }
+}

--- a/ClimbingProgram/features/sessions/LogView.swift
+++ b/ClimbingProgram/features/sessions/LogView.swift
@@ -984,9 +984,21 @@ struct SingleCatalogExercisePicker: View {
 
 private struct CombinedLogList: View {
     @Environment(\.modelContext) private var context
+    @Query(
+        filter: #Predicate<DayTag> { $0.isHidden == false },
+        sort: [
+            SortDescriptor<DayTag>(\DayTag.sort, order: .forward),
+            SortDescriptor<DayTag>(\DayTag.name, order: .forward)
+        ]
+    ) private var tags: [DayTag]
+
     let sessions: [Session]
     let climbEntries: [ClimbEntry]
     let dayLogs: [DayLog]
+
+    @State private var showFilters = false
+    @State private var dateRange = DateRange()
+    @State private var selectedTagIDs: Set<UUID> = []
     
     // Group data by date
     private var groupedData: [Date: LogDaySummary] {
@@ -996,15 +1008,38 @@ private struct CombinedLogList: View {
             dayLogs: dayLogs
         )
     }
+
+    private var filteredData: [Date: LogDaySummary] {
+        LogDaySummaryFilter.filteredSummaries(
+            groupedData,
+            dateRange: dateRange,
+            selectedTagIDs: selectedTagIDs
+        )
+    }
     
     private var sortedDates: [Date] {
-        groupedData.keys.sorted(by: >)
+        filteredData.keys.sorted(by: >)
+    }
+
+    private var allDates: [Date] {
+        groupedData.keys.sorted()
+    }
+
+    private var hasActiveFilters: Bool {
+        LogDaySummaryFilter.isDateFilterActive(
+            dateRange: dateRange,
+            availableDates: allDates
+        ) || !selectedTagIDs.isEmpty
     }
     
     var body: some View {
         List {
+            if !groupedData.isEmpty {
+                filterSection
+            }
+
             ForEach(sortedDates, id: \.self) { date in
-                let dayData = groupedData[date]!
+                let dayData = filteredData[date]!
                 NavigationLink {
                     CombinedDayDetailView(
                         date: date,
@@ -1022,8 +1057,83 @@ private struct CombinedLogList: View {
                 }
             }
             .onDelete(perform: delete)
+
+            if !groupedData.isEmpty, sortedDates.isEmpty {
+                Section {
+                    Text("No days match filters")
+                        .foregroundStyle(.secondary)
+                        .italic()
+                }
+            }
         }
         .listStyle(.insetGrouped)
+        .onAppear(perform: ensureDateRangeInitialized)
+        .onChange(of: groupedData.count) { _, _ in
+            ensureDateRangeInitialized()
+        }
+    }
+
+    @ViewBuilder
+    private var filterSection: some View {
+        Section {
+            VStack(spacing: 4) {
+                Button(action: toggleFilters) {
+                    HStack(spacing: 6) {
+                        Image(systemName: "line.3.horizontal.decrease.circle")
+                        Text(showFilters ? "Hide filters" : "Show filters")
+                        Spacer()
+                        if hasActiveFilters {
+                            Circle()
+                                .fill(Color.accentColor)
+                                .frame(width: 10, height: 10)
+                        }
+                    }
+                    .font(.subheadline)
+                    .padding(.vertical, 6)
+                }
+                .buttonStyle(.plain)
+
+                if showFilters {
+                    LogFilterCard {
+                        VStack(spacing: 10) {
+                            HStack {
+                                HStack {
+                                    Text("Dates")
+                                    DateRangePicker(range: $dateRange)
+                                }
+                                ClearAllButton(
+                                    action: clearAllFilters,
+                                    isEnabled: hasActiveFilters
+                                )
+                            }
+
+                            VStack(alignment: .leading, spacing: 8) {
+                                Text("Tags")
+                                    .font(.callout)
+
+                                if tags.isEmpty {
+                                    Text("No day tags yet")
+                                        .font(.footnote)
+                                        .foregroundStyle(.secondary)
+                                } else {
+                                    FlowLayout(spacing: 8, rowSpacing: 8) {
+                                        ForEach(tags) { tag in
+                                            LogTagFilterChip(
+                                                tag: tag,
+                                                isSelected: selectedTagIDs.contains(tag.id),
+                                                onToggle: { toggleTag(tag) }
+                                            )
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    .padding(.top, 6)
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+                }
+            }
+        }
     }
     
     @MainActor
@@ -1036,7 +1146,7 @@ private struct CombinedLogList: View {
             
             for index in offsets {
                 let date = sortedDates[index]
-                guard let dayData = groupedData[date] else { continue }
+                guard let dayData = filteredData[date] else { continue }
 
                 //If there's a Session, remove its items first
                 if let session = dayData.session {
@@ -1057,6 +1167,101 @@ private struct CombinedLogList: View {
             }
             try? context.save()
         }
+    }
+
+    private func toggleFilters() {
+        withAnimation(.easeInOut(duration: 0.2)) {
+            showFilters.toggle()
+        }
+    }
+
+    private func toggleTag(_ tag: DayTag) {
+        if selectedTagIDs.contains(tag.id) {
+            selectedTagIDs.remove(tag.id)
+        } else {
+            selectedTagIDs.insert(tag.id)
+        }
+    }
+
+    private func clearAllFilters() {
+        dateRange = DateRange()
+        selectedTagIDs.removeAll()
+        ensureDateRangeInitialized()
+    }
+
+    private func ensureDateRangeInitialized() {
+        guard let minDate = allDates.min(), let maxDate = allDates.max() else {
+            dateRange = DateRange()
+            return
+        }
+
+        if dateRange.customStart == nil || (dateRange.customStart ?? minDate) > minDate {
+            dateRange.customStart = minDate
+        }
+
+        if dateRange.customEnd == nil || (dateRange.customEnd ?? maxDate) < maxDate {
+            dateRange.customEnd = maxDate
+        }
+    }
+}
+
+private struct LogFilterCard<Content: View>: View {
+    @ViewBuilder var content: Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            content
+        }
+        .padding(12)
+        .background(
+            .ultraThinMaterial,
+            in: RoundedRectangle(cornerRadius: 16, style: .continuous)
+        )
+    }
+}
+
+private struct LogTagFilterChip: View {
+    let tag: DayTag
+    let isSelected: Bool
+    let onToggle: () -> Void
+
+    private var color: Color {
+        DayTypeModel.color(for: tag.colorKey)
+    }
+
+    var body: some View {
+        Button(action: onToggle) {
+            HStack(spacing: 5) {
+                if isSelected {
+                    Image(systemName: "checkmark")
+                        .font(.caption.bold())
+                }
+
+                Circle()
+                    .fill(color)
+                    .frame(width: 8, height: 8)
+
+                Text(tag.name)
+                    .font(.caption)
+                    .lineLimit(1)
+            }
+        }
+        .buttonStyle(.plain)
+        .font(.caption)
+        .foregroundStyle(isSelected ? .primary : .secondary)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+        .background(isSelected ? color.opacity(0.22) : Color.clear)
+        .overlay {
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(isSelected ? color : .secondary.opacity(0.35), lineWidth: 1)
+        }
+        .clipShape(.rect(cornerRadius: 8))
+        .contentShape(.rect(cornerRadius: 8))
+        .accessibilityLabel(tag.name)
+        .accessibilityValue(isSelected ? "Selected" : "Not selected")
+        .accessibilityHint(isSelected ? "Double tap to remove this tag from the filters." : "Double tap to filter by this tag.")
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 
 }

--- a/ClimbingProgram/features/sessions/LogView.swift
+++ b/ClimbingProgram/features/sessions/LogView.swift
@@ -1075,65 +1075,66 @@ private struct CombinedLogList: View {
 
     @ViewBuilder
     private var filterSection: some View {
-        Section {
-            VStack(spacing: 4) {
-                Button(action: toggleFilters) {
-                    HStack(spacing: 6) {
-                        Image(systemName: "line.3.horizontal.decrease.circle")
-                        Text(showFilters ? "Hide filters" : "Show filters")
-                        Spacer()
-                        if hasActiveFilters {
-                            Circle()
-                                .fill(Color.accentColor)
-                                .frame(width: 10, height: 10)
-                        }
+        VStack(spacing: 4) {
+            Button(action: toggleFilters) {
+                HStack(spacing: 6) {
+                    Image(systemName: "line.3.horizontal.decrease.circle")
+                    Text(showFilters ? "Hide filters" : "Show filters")
+                    Spacer()
+                    if hasActiveFilters {
+                        Circle()
+                            .fill(Color.accentColor)
+                            .frame(width: 10, height: 10)
                     }
-                    .font(.subheadline)
-                    .padding(.vertical, 6)
                 }
-                .buttonStyle(.plain)
+                .font(.subheadline)
+                .padding(.vertical, 2)
+            }
+            .buttonStyle(.plain)
 
-                if showFilters {
-                    LogFilterCard {
-                        VStack(spacing: 10) {
+            if showFilters {
+                LogFilterCard {
+                    VStack(spacing: 10) {
+                        HStack {
                             HStack {
-                                HStack {
-                                    Text("Dates")
-                                    DateRangePicker(range: $dateRange)
-                                }
-                                ClearAllButton(
-                                    action: clearAllFilters,
-                                    isEnabled: hasActiveFilters
-                                )
+                                Text("Dates")
+                                DateRangePicker(range: $dateRange)
                             }
+                            ClearAllButton(
+                                action: clearAllFilters,
+                                isEnabled: hasActiveFilters
+                            )
+                        }
 
-                            VStack(alignment: .leading, spacing: 8) {
-                                Text("Tags")
-                                    .font(.callout)
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("Tags")
+                                .font(.callout)
 
-                                if tags.isEmpty {
-                                    Text("No day tags yet")
-                                        .font(.footnote)
-                                        .foregroundStyle(.secondary)
-                                } else {
-                                    FlowLayout(spacing: 8, rowSpacing: 8) {
-                                        ForEach(tags) { tag in
-                                            LogTagFilterChip(
-                                                tag: tag,
-                                                isSelected: selectedTagIDs.contains(tag.id),
-                                                onToggle: { toggleTag(tag) }
-                                            )
-                                        }
+                            if tags.isEmpty {
+                                Text("No day tags yet")
+                                    .font(.footnote)
+                                    .foregroundStyle(.secondary)
+                            } else {
+                                FlowLayout(spacing: 8, rowSpacing: 8) {
+                                    ForEach(tags) { tag in
+                                        LogTagFilterChip(
+                                            tag: tag,
+                                            isSelected: selectedTagIDs.contains(tag.id),
+                                            onToggle: { toggleTag(tag) }
+                                        )
                                     }
                                 }
                             }
                         }
                     }
-                    .padding(.top, 6)
-                    .transition(.opacity.combined(with: .move(edge: .top)))
                 }
+                .padding(.top, 2)
+                .transition(.opacity.combined(with: .move(edge: .top)))
             }
         }
+        .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: showFilters ? 6 : 0, trailing: 16))
+        .listRowBackground(Color.clear)
+        .listRowSeparator(.hidden)
     }
     
     @MainActor

--- a/ClimbingProgram/features/sessions/LogView.swift
+++ b/ClimbingProgram/features/sessions/LogView.swift
@@ -52,6 +52,7 @@ struct LogView: View {
     @Environment(\.isDataReady) private var isDataReady
     @Query(sort: [SortDescriptor(\Session.date, order: .reverse)]) private var sessions: [Session]
     @Query(sort: [SortDescriptor(\ClimbEntry.dateLogged, order: .reverse)]) private var climbEntries: [ClimbEntry]
+    @Query(sort: [SortDescriptor(\DayLog.date, order: .reverse)]) private var dayLogs: [DayLog]
 
     @State private var modalRoute: ModalRoute?
     @State private var navigationPath = NavigationPath()
@@ -73,7 +74,7 @@ struct LogView: View {
 
     var body: some View {
             NavigationStack(path: $navigationPath) {
-                CombinedLogList(sessions: sessions, climbEntries: climbEntries)
+                CombinedLogList(sessions: sessions, climbEntries: climbEntries, dayLogs: dayLogs)
                     .toolbar { trailingToolbar }
                     .sheet(isPresented: newSessionPresentedBinding) {
                         NewSessionSheet { createdDay in
@@ -92,11 +93,15 @@ struct LogView: View {
                         let climbsForDay = climbEntries.filter {
                             Calendar.current.startOfDay(for: $0.dateLogged) == dayKey
                         }
+                        let dayLogForDay = dayLogs.first {
+                            Calendar.current.startOfDay(for: $0.date) == dayKey
+                        }
 
                         CombinedDayDetailView(
                             date: dayKey,
                             session: sessionForDay,
-                            climbEntries: climbsForDay
+                            climbEntries: climbsForDay,
+                            dayLog: dayLogForDay
                         )
                     }
             }
@@ -981,32 +986,15 @@ private struct CombinedLogList: View {
     @Environment(\.modelContext) private var context
     let sessions: [Session]
     let climbEntries: [ClimbEntry]
+    let dayLogs: [DayLog]
     
     // Group data by date
-    private var groupedData: [Date: (exercises: Int, climbs: Int, session: Session?, climbEntries: [ClimbEntry])] {
-        var grouped: [Date: (exercises: Int, climbs: Int, session: Session?, climbEntries: [ClimbEntry])] = [:]
-        
-        // Add sessions (exercises)
-        for session in sessions {
-            let dateKey = Calendar.current.startOfDay(for: session.date)
-            if grouped[dateKey] == nil {
-                grouped[dateKey] = (exercises: 0, climbs: 0, session: nil, climbEntries: [])
-            }
-            grouped[dateKey]?.exercises = Array(session.items).count
-            grouped[dateKey]?.session = session
-        }
-        
-        // Add climb entries
-        for climb in climbEntries {
-            let dateKey = Calendar.current.startOfDay(for: climb.dateLogged)
-            if grouped[dateKey] == nil {
-                grouped[dateKey] = (exercises: 0, climbs: 0, session: nil, climbEntries: [])
-            }
-            grouped[dateKey]?.climbs += 1
-            grouped[dateKey]?.climbEntries.append(climb)
-        }
-        
-        return grouped
+    private var groupedData: [Date: LogDaySummary] {
+        LogDaySummaryBuilder.build(
+            sessions: sessions,
+            climbEntries: climbEntries,
+            dayLogs: dayLogs
+        )
     }
     
     private var sortedDates: [Date] {
@@ -1021,13 +1009,15 @@ private struct CombinedLogList: View {
                     CombinedDayDetailView(
                         date: date,
                         session: dayData.session,
-                        climbEntries: dayData.climbEntries
+                        climbEntries: dayData.climbEntries,
+                        dayLog: dayData.dayLog
                     )
                 } label: {
                     CombinedDayRow(
                         date: date,
                         exerciseCount: dayData.exercises,
-                        climbCount: dayData.climbs
+                        climbCount: dayData.climbs,
+                        dayLog: dayData.dayLog
                     )
                 }
             }
@@ -1060,6 +1050,10 @@ private struct CombinedLogList: View {
                 for climb in dayData.climbEntries {
                     context.delete(climb)
                 }
+
+                if let dayLog = dayData.dayLog {
+                    context.delete(dayLog)
+                }
             }
             try? context.save()
         }
@@ -1071,6 +1065,11 @@ private struct CombinedDayRow: View {
     let date: Date
     let exerciseCount: Int
     let climbCount: Int
+    let dayLog: DayLog?
+
+    private var tags: [DayTag] {
+        DayLogStore.activeTags(from: dayLog)
+    }
     
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
@@ -1117,6 +1116,10 @@ private struct CombinedDayRow: View {
                         .foregroundStyle(.secondary)
                 }
             }
+
+            if !tags.isEmpty {
+                DayTagChips(tags: tags)
+            }
         }
         .padding(.vertical, 2)
     }
@@ -1139,11 +1142,13 @@ private struct CombinedDayDetailView: View {
     let date: Date
     let session: Session?
     let climbEntries: [ClimbEntry]
+    let dayLog: DayLog?
     
     @State private var addRoute: AddRoute? = nil
     @State private var didReorder = false
     @State private var editingClimb: ClimbEntry? = nil
     @State private var editingItem: SessionItem? = nil
+    @State private var localDayLog: DayLog? = nil
     // Quick Progress
     @State private var progressExercise: ExerciseSelection? = nil
     //multi-exercise add flow
@@ -1154,9 +1159,19 @@ private struct CombinedDayDetailView: View {
     private var sortedClimbs: [ClimbEntry] {
         climbEntries.sorted(by: { $0.dateLogged > $1.dateLogged })
     }
+
+    private var resolvedDayLog: DayLog? {
+        localDayLog ?? dayLog
+    }
     
     var body: some View {
         List {
+            DayContextEditorSection(
+                date: date,
+                dayLog: resolvedDayLog,
+                onDayLogChanged: updateDayLog
+            )
+
             // Exercises section
             if let session = session, !session.items.isEmpty {
                 Section("Exercises") {
@@ -1311,7 +1326,6 @@ private struct CombinedDayDetailView: View {
         .sheet(item: $progressExercise) { sel in
             QuickExerciseProgress(exerciseName: sel.name)
         }
-
         // Commit once when leaving edit mode, but only if a reorder occurred
         .onChange(of: editMode?.wrappedValue) { _, newValue in
             if newValue == .inactive, didReorder {
@@ -1325,8 +1339,14 @@ private struct CombinedDayDetailView: View {
                 try? context.save()
             }
         }
+        .onAppear {
+            localDayLog = dayLog
+        }
     }
 
+    private func updateDayLog(_ dayLog: DayLog?) {
+        localDayLog = dayLog
+    }
     
     private func addExercise() {
         guard isDataReady else { return }

--- a/ClimbingProgram/shared/DayContextViews.swift
+++ b/ClimbingProgram/shared/DayContextViews.swift
@@ -1,0 +1,413 @@
+//
+//  DayContextViews.swift
+//  klettrack
+//
+
+import SwiftUI
+import SwiftData
+
+struct DayTagChip: View {
+    let tag: DayTag
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Circle()
+                .fill(DayTypeModel.color(for: tag.colorKey))
+                .frame(width: 7, height: 7)
+            Text(tag.name)
+                .lineLimit(1)
+        }
+        .font(.caption2)
+        .padding(.horizontal, 7)
+        .padding(.vertical, 3)
+        .background(DayTypeModel.color(for: tag.colorKey).opacity(0.16))
+        .foregroundStyle(.primary)
+        .clipShape(.rect(cornerRadius: 5))
+    }
+}
+
+struct DayTagChips: View {
+    let tags: [DayTag]
+
+    var body: some View {
+        if !tags.isEmpty {
+            FlowLayout(spacing: 6, rowSpacing: 6) {
+                ForEach(tags) { tag in
+                    DayTagChip(tag: tag)
+                }
+            }
+        }
+    }
+}
+
+struct DayTagPresentation: Identifiable {
+    let tag: DayTag
+    let isSelected: Bool
+
+    var id: UUID { tag.id }
+}
+
+@MainActor
+enum DayTagPresentationBuilder {
+    static func orderedTags(allTags: [DayTag], selectedTags: [DayTag]) -> [DayTagPresentation] {
+        let selectedIds = Set(selectedTags.filter { !$0.isHidden }.map(\.id))
+        let activeTags = allTags
+            .filter { !$0.isHidden }
+            .sorted { lhs, rhs in
+                if lhs.sort != rhs.sort { return lhs.sort < rhs.sort }
+                return lhs.name.localizedStandardCompare(rhs.name) == .orderedAscending
+            }
+
+        let selected = activeTags
+            .filter { selectedIds.contains($0.id) }
+            .map { DayTagPresentation(tag: $0, isSelected: true) }
+        let unselected = activeTags
+            .filter { !selectedIds.contains($0.id) }
+            .map { DayTagPresentation(tag: $0, isSelected: false) }
+        return selected + unselected
+    }
+}
+
+struct DayContextEditorSection: View {
+    @Environment(\.modelContext) private var context
+
+    let date: Date
+    let dayLog: DayLog?
+    let onDayLogChanged: (DayLog?) -> Void
+
+    @Query(
+        filter: #Predicate<DayTag> { $0.isHidden == false },
+        sort: [
+            SortDescriptor<DayTag>(\DayTag.sort, order: .forward),
+            SortDescriptor<DayTag>(\DayTag.name, order: .forward)
+        ]
+    ) private var tags: [DayTag]
+
+    @State private var noteText = ""
+    @State private var newTagName = ""
+    @State private var newTagColorKey = "gray"
+    @State private var errorMessage: String?
+    @FocusState private var isNewTagFocused: Bool
+
+    private var selectedTags: [DayTag] {
+        DayLogStore.activeTags(from: dayLog)
+    }
+
+    private var presentedTags: [DayTagPresentation] {
+        DayTagPresentationBuilder.orderedTags(allTags: tags, selectedTags: selectedTags)
+    }
+
+    private var trimmedNewTagName: String {
+        newTagName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var shouldShowNewTagControls: Bool {
+        isNewTagFocused || !trimmedNewTagName.isEmpty
+    }
+
+    var body: some View {
+        Section("Day Context") {
+            TextField("Daily note", text: $noteText, axis: .vertical)
+                .lineLimit(2...6)
+                .onChange(of: noteText) { _, _ in
+                    saveNote()
+                }
+
+            VStack(alignment: .leading, spacing: 10) {
+                if presentedTags.isEmpty {
+                    Text("No tags yet")
+                        .foregroundStyle(.secondary)
+                }
+
+                FlowLayout(spacing: 8, rowSpacing: 8) {
+                    ForEach(presentedTags) { presentation in
+                        DayTagToggleChip(
+                            tag: presentation.tag,
+                            isSelected: presentation.isSelected,
+                            onToggle: { toggle(presentation.tag) }
+                        )
+                    }
+
+                    NewLabelChip(name: $newTagName, colorKey: newTagColorKey)
+                        .focused($isNewTagFocused)
+                        .onSubmit(addTag)
+                }
+
+                if shouldShowNewTagControls {
+                    inlineTagControls
+                }
+            }
+            .padding(.vertical, 2)
+        }
+        .onAppear(perform: syncNoteText)
+        .onChange(of: dayLog?.id) { _, _ in
+            syncNoteText()
+        }
+        .onChange(of: dayLog?.note) { _, _ in
+            syncNoteText()
+        }
+        .onChange(of: date) { _, _ in
+            syncNoteText()
+        }
+        .alert(errorMessage ?? "", isPresented: Binding(
+            get: { errorMessage != nil },
+            set: { if !$0 { errorMessage = nil } }
+        )) {
+            Button("OK", role: .cancel) { }
+        }
+    }
+
+    private var inlineTagControls: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            ColorKeyPicker(selection: $newTagColorKey)
+
+            HStack {
+                Button("Cancel", role: .cancel, action: resetNewTagInput)
+                    .buttonStyle(.borderless)
+                Spacer()
+                Button("Create", action: addTag)
+                    .buttonStyle(.borderless)
+                    .disabled(trimmedNewTagName.isEmpty)
+            }
+        }
+    }
+
+    private func syncNoteText() {
+        let currentNote = dayLog?.note ?? ""
+        if noteText != currentNote {
+            noteText = currentNote
+        }
+    }
+
+    private func editableDayLog(createIfMissing: Bool = true) -> DayLog? {
+        let editable = DayLogStore.dayLog(for: date, in: context, createIfMissing: createIfMissing)
+        if editable?.id != dayLog?.id {
+            onDayLogChanged(editable)
+        }
+        return editable
+    }
+
+    private func saveNote() {
+        let trimmed = noteText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty || dayLog != nil else { return }
+        guard let editable = editableDayLog() else { return }
+        if editable.note != trimmed {
+            DayLogStore.setNote(noteText, for: editable)
+            try? context.save()
+            onDayLogChanged(editable)
+        }
+    }
+
+    private func toggle(_ tag: DayTag) {
+        guard let editable = editableDayLog() else { return }
+        let isAssigned = DayLogStore.activeTags(from: editable).contains { $0.id == tag.id }
+        DayLogStore.setTag(tag, assigned: !isAssigned, to: editable)
+        try? context.save()
+        onDayLogChanged(editable)
+    }
+
+    private func resetNewTagInput() {
+        newTagName = ""
+        newTagColorKey = "gray"
+        isNewTagFocused = false
+    }
+
+    private func addTag() {
+        let trimmed = trimmedNewTagName
+        guard !trimmed.isEmpty else { return }
+        guard DayLogStore.activeTag(named: trimmed, in: context) == nil else {
+            errorMessage = "A tag with this name already exists."
+            return
+        }
+        guard let editable = editableDayLog(),
+              let tag = DayLogStore.createTag(name: trimmed, colorKey: newTagColorKey, in: context)
+        else { return }
+        DayLogStore.setTag(tag, assigned: true, to: editable)
+        try? context.save()
+        onDayLogChanged(editable)
+        resetNewTagInput()
+    }
+}
+
+private struct NewLabelChip: View {
+    @Binding var name: String
+    let colorKey: String
+
+    private var color: Color {
+        DayTypeModel.color(for: colorKey)
+    }
+
+    var body: some View {
+        HStack(spacing: 5) {
+            Circle()
+                .fill(color)
+                .frame(width: 8, height: 8)
+
+            TextField("New label", text: $name)
+                .font(.caption)
+                .textFieldStyle(.plain)
+                .textInputAutocapitalization(.words)
+                .autocorrectionDisabled()
+                .submitLabel(.done)
+                .lineLimit(1)
+                .frame(width: 70)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(.secondary.opacity(0.12))
+        .overlay {
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(.secondary.opacity(0.25), lineWidth: 1)
+        }
+        .clipShape(.rect(cornerRadius: 8))
+        .accessibilityElement(children: .contain)
+    }
+}
+
+private struct DayTagToggleChip: View {
+    let tag: DayTag
+    let isSelected: Bool
+    let onToggle: () -> Void
+
+    private var color: Color {
+        DayTypeModel.color(for: tag.colorKey)
+    }
+
+    var body: some View {
+        Button(action: onToggle) {
+            HStack(spacing: 5) {
+                if isSelected {
+                    Image(systemName: "checkmark")
+                        .font(.caption.bold())
+                }
+
+                Circle()
+                    .fill(color)
+                    .frame(width: 8, height: 8)
+
+                Text(tag.name)
+                    .font(.caption)
+                    .lineLimit(1)
+            }
+        }
+        .buttonStyle(.plain)
+        .font(.caption)
+        .foregroundStyle(isSelected ? .primary : .secondary)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 7)
+        .background(isSelected ? color.opacity(0.22) : Color.clear)
+        .overlay {
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(isSelected ? color : .secondary.opacity(0.35), lineWidth: 1)
+        }
+        .clipShape(.rect(cornerRadius: 8))
+        .contentShape(.rect(cornerRadius: 8))
+        .accessibilityLabel(tag.name)
+        .accessibilityValue(isSelected ? "Selected" : "Not selected")
+        .accessibilityHint(isSelected ? "Double tap to remove this tag from the day." : "Double tap to assign this tag to the day.")
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+}
+
+struct ColorKeyPicker: View {
+    @Binding var selection: String
+
+    private var sortedKeys: [String] {
+        let preferred = ["green","blue","indigo","purple","pink","red","orange","yellow","mint","teal","cyan","brown","gray","black","white"]
+        let allowed = Array(DayTypeModel.allowedColorKeys)
+        let remaining = allowed.filter { !preferred.contains($0) }.sorted()
+        return preferred.filter { allowed.contains($0) } + remaining
+    }
+
+    var body: some View {
+        LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 12), count: 6), spacing: 12) {
+            ForEach(sortedKeys, id: \.self) { key in
+                Button {
+                    selection = key
+                } label: {
+                    ZStack {
+                        Circle()
+                            .fill(DayTypeModel.color(for: key))
+                            .frame(width: 28, height: 28)
+                        if selection == key {
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundStyle(.white)
+                                .shadow(radius: 1)
+                        }
+                    }
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(key)
+                .accessibilityValue(selection == key ? "Selected" : "Not selected")
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+struct FlowLayout: Layout {
+    var spacing: CGFloat = 6
+    var rowSpacing: CGFloat = 6
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let width = proposal.width ?? 0
+        let rows = rows(in: width, subviews: subviews)
+        return CGSize(
+            width: width,
+            height: rows.reduce(0) { $0 + $1.height } + CGFloat(max(0, rows.count - 1)) * rowSpacing
+        )
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        let rows = rows(in: bounds.width, subviews: subviews)
+        var y = bounds.minY
+        for row in rows {
+            var x = bounds.minX
+            for item in row.items {
+                subviews[item.index].place(
+                    at: CGPoint(x: x, y: y),
+                    proposal: ProposedViewSize(item.size)
+                )
+                x += item.size.width + spacing
+            }
+            y += row.height + rowSpacing
+        }
+    }
+
+    private func rows(in width: CGFloat, subviews: Subviews) -> [Row] {
+        var rows: [Row] = []
+        var currentItems: [Item] = []
+        var currentWidth: CGFloat = 0
+        var currentHeight: CGFloat = 0
+
+        for index in subviews.indices {
+            let size = subviews[index].sizeThatFits(.unspecified)
+            let proposedWidth = currentItems.isEmpty ? size.width : currentWidth + spacing + size.width
+            if proposedWidth > width, !currentItems.isEmpty {
+                rows.append(Row(items: currentItems, height: currentHeight))
+                currentItems = [Item(index: index, size: size)]
+                currentWidth = size.width
+                currentHeight = size.height
+            } else {
+                currentItems.append(Item(index: index, size: size))
+                currentWidth = proposedWidth
+                currentHeight = max(currentHeight, size.height)
+            }
+        }
+
+        if !currentItems.isEmpty {
+            rows.append(Row(items: currentItems, height: currentHeight))
+        }
+        return rows
+    }
+
+    private struct Row {
+        let items: [Item]
+        let height: CGFloat
+    }
+
+    private struct Item {
+        let index: Int
+        let size: CGSize
+    }
+}

--- a/ClimbingProgramTests/ClimbingProgramTestSuite.swift
+++ b/ClimbingProgramTests/ClimbingProgramTestSuite.swift
@@ -30,6 +30,8 @@ class ClimbingProgramTestSuite: XCTestCase {
             // Sessions (log)
             Session.self,
             SessionItem.self,
+            DayLog.self,
+            DayTag.self,
 
             // Timer
             TimerTemplate.self,

--- a/ClimbingProgramTests/DayLogStoreTests.swift
+++ b/ClimbingProgramTests/DayLogStoreTests.swift
@@ -47,6 +47,23 @@ final class DayLogStoreTests: BaseSwiftDataTestCase {
         XCTAssertTrue(DayLogStore.activeTags(from: dayLog).isEmpty)
     }
 
+    func testSameTagCanBeAssignedToMultipleDayLogs() throws {
+        let calendar = Calendar.current
+        let firstDate = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 7, day: 24)))
+        let secondDate = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 7, day: 25)))
+        let firstDayLog = try XCTUnwrap(DayLogStore.dayLog(for: firstDate, in: context))
+        let secondDayLog = try XCTUnwrap(DayLogStore.dayLog(for: secondDate, in: context))
+        let tag = try XCTUnwrap(DayLogStore.createTag(name: "Volume", colorKey: "green", in: context))
+
+        DayLogStore.setTag(tag, assigned: true, to: firstDayLog)
+        DayLogStore.setTag(tag, assigned: true, to: secondDayLog)
+        try context.save()
+
+        XCTAssertEqual(DayLogStore.activeTags(from: firstDayLog).map(\.id), [tag.id])
+        XCTAssertEqual(DayLogStore.activeTags(from: secondDayLog).map(\.id), [tag.id])
+        XCTAssertEqual(Set(tag.dayLogs?.map(\.id) ?? []), [firstDayLog.id, secondDayLog.id])
+    }
+
     func testFetchWithoutCreateDoesNotInsertEmptyDayLog() throws {
         let day = try XCTUnwrap(Calendar.current.date(from: DateComponents(year: 2026, month: 7, day: 29)))
 

--- a/ClimbingProgramTests/DayLogStoreTests.swift
+++ b/ClimbingProgramTests/DayLogStoreTests.swift
@@ -146,4 +146,116 @@ final class DayLogStoreTests: BaseSwiftDataTestCase {
         XCTAssertEqual(grouped[mixedKey]?.exercises, 1)
         XCTAssertEqual(DayLogStore.activeTags(from: grouped[mixedKey]?.dayLog).map(\.name), ["Volume"])
     }
+
+    func testLogFilterDateRangeIncludesStartAndEndDays() throws {
+        let calendar = Calendar.current
+        let first = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 7, day: 24)))
+        let second = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 7, day: 25)))
+        let third = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 7, day: 26)))
+        let grouped = logSummaries(for: [first, second, third], calendar: calendar)
+
+        let filtered = LogDaySummaryFilter.filteredSummaries(
+            grouped,
+            dateRange: DateRange(customStart: first, customEnd: second),
+            selectedTagIDs: [],
+            calendar: calendar
+        )
+
+        XCTAssertEqual(Set(filtered.keys), Set([first, second].map { calendar.startOfDay(for: $0) }))
+    }
+
+    func testLogFilterMatchesAnySelectedTag() throws {
+        let calendar = Calendar.current
+        let volume = try XCTUnwrap(DayLogStore.createTag(name: "Volume", colorKey: "green", in: context))
+        let project = try XCTUnwrap(DayLogStore.createTag(name: "Project", colorKey: "red", in: context))
+        let travel = try XCTUnwrap(DayLogStore.createTag(name: "Travel", colorKey: "blue", in: context))
+        let volumeDay = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 7, day: 24)))
+        let projectDay = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 7, day: 25)))
+        let travelDay = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 7, day: 26)))
+        let grouped = [
+            calendar.startOfDay(for: volumeDay): LogDaySummary(dayLog: dayLog(on: volumeDay, tags: [volume])),
+            calendar.startOfDay(for: projectDay): LogDaySummary(dayLog: dayLog(on: projectDay, tags: [project])),
+            calendar.startOfDay(for: travelDay): LogDaySummary(dayLog: dayLog(on: travelDay, tags: [travel]))
+        ]
+
+        let filtered = LogDaySummaryFilter.filteredSummaries(
+            grouped,
+            dateRange: DateRange(),
+            selectedTagIDs: [volume.id, project.id],
+            calendar: calendar
+        )
+
+        XCTAssertEqual(Set(filtered.keys), Set([volumeDay, projectDay].map { calendar.startOfDay(for: $0) }))
+    }
+
+    func testLogFilterCombinesDateAndTagsWithAndBehavior() throws {
+        let calendar = Calendar.current
+        let volume = try XCTUnwrap(DayLogStore.createTag(name: "Volume", colorKey: "green", in: context))
+        let project = try XCTUnwrap(DayLogStore.createTag(name: "Project", colorKey: "red", in: context))
+        let first = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 7, day: 24)))
+        let second = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 7, day: 25)))
+        let third = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 7, day: 26)))
+        let grouped = [
+            calendar.startOfDay(for: first): LogDaySummary(dayLog: dayLog(on: first, tags: [volume])),
+            calendar.startOfDay(for: second): LogDaySummary(dayLog: dayLog(on: second, tags: [project])),
+            calendar.startOfDay(for: third): LogDaySummary(dayLog: dayLog(on: third, tags: [volume]))
+        ]
+
+        let filtered = LogDaySummaryFilter.filteredSummaries(
+            grouped,
+            dateRange: DateRange(customStart: first, customEnd: second),
+            selectedTagIDs: [volume.id],
+            calendar: calendar
+        )
+
+        XCTAssertEqual(Set(filtered.keys), [calendar.startOfDay(for: first)])
+    }
+
+    func testLogFilterNoSelectedTagsLeavesTagFilteringInactive() throws {
+        let calendar = Calendar.current
+        let volume = try XCTUnwrap(DayLogStore.createTag(name: "Volume", colorKey: "green", in: context))
+        let first = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 7, day: 24)))
+        let second = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 7, day: 25)))
+        let grouped = [
+            calendar.startOfDay(for: first): LogDaySummary(dayLog: dayLog(on: first, tags: [volume])),
+            calendar.startOfDay(for: second): LogDaySummary()
+        ]
+
+        let filtered = LogDaySummaryFilter.filteredSummaries(
+            grouped,
+            dateRange: DateRange(),
+            selectedTagIDs: [],
+            calendar: calendar
+        )
+
+        XCTAssertEqual(Set(filtered.keys), Set(grouped.keys))
+    }
+
+    func testLogFilterResetEquivalentReturnsAllGroupedDays() throws {
+        let calendar = Calendar.current
+        let first = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 7, day: 24)))
+        let second = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 7, day: 25)))
+        let grouped = logSummaries(for: [first, second], calendar: calendar)
+
+        let filtered = LogDaySummaryFilter.filteredSummaries(
+            grouped,
+            dateRange: DateRange(),
+            selectedTagIDs: [],
+            calendar: calendar
+        )
+
+        XCTAssertEqual(Set(filtered.keys), Set(grouped.keys))
+    }
+
+    private func logSummaries(for dates: [Date], calendar: Calendar) -> [Date: LogDaySummary] {
+        Dictionary(uniqueKeysWithValues: dates.map { date in
+            (calendar.startOfDay(for: date), LogDaySummary())
+        })
+    }
+
+    private func dayLog(on date: Date, tags: [DayTag]) -> DayLog {
+        let log = DayLog(date: date, tags: tags)
+        context.insert(log)
+        return log
+    }
 }

--- a/ClimbingProgramTests/DayLogStoreTests.swift
+++ b/ClimbingProgramTests/DayLogStoreTests.swift
@@ -1,0 +1,149 @@
+import XCTest
+import SwiftData
+@testable import klettrack
+
+@MainActor
+final class DayLogStoreTests: BaseSwiftDataTestCase {
+    func testFetchOrCreateNormalizesToOneDayLogPerDate() throws {
+        let calendar = Calendar.current
+        let morning = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 7, day: 27, hour: 9)))
+        let evening = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 7, day: 27, hour: 20)))
+
+        let first = try XCTUnwrap(DayLogStore.dayLog(for: morning, in: context))
+        let second = try XCTUnwrap(DayLogStore.dayLog(for: evening, in: context))
+
+        XCTAssertEqual(first.id, second.id)
+        XCTAssertEqual(first.date, calendar.startOfDay(for: morning))
+    }
+
+    func testSetNoteTrimsEmptyValuesToNil() throws {
+        let dayLog = try XCTUnwrap(DayLogStore.dayLog(for: Date(), in: context))
+
+        DayLogStore.setNote("  Good session  ", for: dayLog)
+        XCTAssertEqual(dayLog.note, "Good session")
+
+        DayLogStore.setNote("   \n ", for: dayLog)
+        XCTAssertNil(dayLog.note)
+    }
+
+    func testCreateTagPreventsDuplicateActiveNames() throws {
+        let first = try XCTUnwrap(DayLogStore.createTag(name: " Projecting ", colorKey: "red", in: context))
+        let second = try XCTUnwrap(DayLogStore.createTag(name: "projecting", colorKey: "blue", in: context))
+
+        XCTAssertEqual(first.id, second.id)
+        XCTAssertEqual(first.name, "Projecting")
+        XCTAssertEqual(first.colorKey, "red")
+    }
+
+    func testAssignAndHideTagRemovesItFromDayLog() throws {
+        let dayLog = try XCTUnwrap(DayLogStore.dayLog(for: Date(), in: context))
+        let tag = try XCTUnwrap(DayLogStore.createTag(name: "Volume", colorKey: "green", in: context))
+
+        DayLogStore.setTag(tag, assigned: true, to: dayLog)
+        XCTAssertEqual(DayLogStore.activeTags(from: dayLog).map(\.id), [tag.id])
+
+        DayLogStore.hideTag(tag, in: context)
+        XCTAssertTrue(tag.isHidden)
+        XCTAssertTrue(DayLogStore.activeTags(from: dayLog).isEmpty)
+    }
+
+    func testFetchWithoutCreateDoesNotInsertEmptyDayLog() throws {
+        let day = try XCTUnwrap(Calendar.current.date(from: DateComponents(year: 2026, month: 7, day: 29)))
+
+        XCTAssertNil(DayLogStore.dayLog(for: day, in: context, createIfMissing: false))
+
+        let descriptor = FetchDescriptor<DayLog>()
+        XCTAssertEqual((try? context.fetch(descriptor))?.count, 0)
+    }
+
+    func testTagPresentationOrdersSelectedTagsBeforeUnselectedTags() throws {
+        let selectedLaterSort = DayTag(name: "Project", colorKey: "red", sort: 20)
+        let unselectedEarlierSort = DayTag(name: "Easy", colorKey: "green", sort: 0)
+        let selectedEarlierSort = DayTag(name: "Volume", colorKey: "blue", sort: 10)
+        let unselectedSameSortA = DayTag(name: "Alpha", colorKey: "gray", sort: 30)
+        let unselectedSameSortB = DayTag(name: "Beta", colorKey: "gray", sort: 30)
+        let hidden = DayTag(name: "Hidden", colorKey: "gray", sort: -10, isHidden: true)
+
+        let presentations = DayTagPresentationBuilder.orderedTags(
+            allTags: [
+                unselectedSameSortB,
+                selectedLaterSort,
+                hidden,
+                unselectedEarlierSort,
+                unselectedSameSortA,
+                selectedEarlierSort
+            ],
+            selectedTags: [selectedLaterSort, selectedEarlierSort, hidden]
+        )
+
+        XCTAssertEqual(presentations.map { $0.tag.name }, ["Volume", "Project", "Easy", "Alpha", "Beta"])
+        XCTAssertEqual(presentations.map(\.isSelected), [true, true, false, false, false])
+    }
+
+    func testBackfillCopiesLegacyPlanDayNotesToSharedDayLog() throws {
+        let day = try XCTUnwrap(Calendar.current.date(from: DateComponents(year: 2026, month: 7, day: 27)))
+        let planDay = PlanDay(date: day)
+        planDay.dailyNotes = "Legacy note"
+        context.insert(planDay)
+
+        backfillDayLogsFromPlanDayNotes(context)
+
+        let dayLog = try XCTUnwrap(DayLogStore.fetchDayLog(for: day, in: context))
+        XCTAssertEqual(dayLog.note, "Legacy note")
+    }
+
+    func testBackfillKeepsExistingSharedNoteWhenLegacyDuplicatesExist() throws {
+        let day = try XCTUnwrap(Calendar.current.date(from: DateComponents(year: 2026, month: 7, day: 28)))
+        let existing = try XCTUnwrap(DayLogStore.dayLog(for: day, in: context))
+        existing.note = "Existing shared note"
+
+        let first = PlanDay(date: day)
+        first.dailyNotes = "Legacy note"
+        let second = PlanDay(date: day)
+        second.dailyNotes = "Duplicate note"
+        context.insert(first)
+        context.insert(second)
+
+        backfillDayLogsFromPlanDayNotes(context)
+
+        let dayLog = try XCTUnwrap(DayLogStore.fetchDayLog(for: day, in: context))
+        XCTAssertEqual(dayLog.note, "Existing shared note")
+    }
+
+    func testLogSummaryIncludesActivityOnlyMetadataOnlyAndMixedDays() throws {
+        let calendar = Calendar.current
+        let activityOnlyDay = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 7, day: 24, hour: 10)))
+        let metadataOnlyDay = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 7, day: 25, hour: 10)))
+        let mixedDay = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 7, day: 26, hour: 10)))
+
+        let activitySession = createTestSession(date: activityOnlyDay)
+        activitySession.items.append(SessionItem(exerciseName: "Rows"))
+
+        let metadataOnlyLog = try XCTUnwrap(DayLogStore.dayLog(for: metadataOnlyDay, in: context))
+        metadataOnlyLog.note = "Travel day"
+
+        let mixedSession = createTestSession(date: mixedDay)
+        mixedSession.items.append(SessionItem(exerciseName: "Pullups"))
+        let mixedLog = try XCTUnwrap(DayLogStore.dayLog(for: mixedDay, in: context))
+        let tag = try XCTUnwrap(DayLogStore.createTag(name: "Volume", colorKey: "green", in: context))
+        DayLogStore.setTag(tag, assigned: true, to: mixedLog)
+
+        let grouped = LogDaySummaryBuilder.build(
+            sessions: [activitySession, mixedSession],
+            climbEntries: [],
+            dayLogs: [metadataOnlyLog, mixedLog],
+            calendar: calendar
+        )
+
+        let activityKey = calendar.startOfDay(for: activityOnlyDay)
+        let metadataKey = calendar.startOfDay(for: metadataOnlyDay)
+        let mixedKey = calendar.startOfDay(for: mixedDay)
+
+        XCTAssertEqual(grouped[activityKey]?.exercises, 1)
+        XCTAssertNil(grouped[activityKey]?.dayLog)
+        XCTAssertEqual(grouped[metadataKey]?.dayLog?.note, "Travel day")
+        XCTAssertEqual(grouped[metadataKey]?.exercises, 0)
+        XCTAssertEqual(grouped[mixedKey]?.exercises, 1)
+        XCTAssertEqual(DayLogStore.activeTags(from: grouped[mixedKey]?.dayLog).map(\.name), ["Volume"])
+    }
+}

--- a/ClimbingProgramTests/TestSupport.swift
+++ b/ClimbingProgramTests/TestSupport.swift
@@ -12,6 +12,7 @@ class BaseSwiftDataTestCase: XCTestCase {
         let types: [any PersistentModel.Type] = [
             Activity.self, TrainingType.self, Exercise.self, BoulderCombination.self,
             Session.self, SessionItem.self,
+            DayLog.self, DayTag.self,
             Plan.self, PlanDay.self,
             TimerTemplate.self, TimerInterval.self, TimerSession.self, TimerLap.self,
             ClimbEntry.self, ClimbStyle.self, ClimbGym.self, ClimbMedia.self,


### PR DESCRIPTION
## Summary
- add shared SwiftData day context models for one daily note and assigned tags per calendar day
- migrate legacy PlanDay daily notes into shared DayLog records and switch Plan/Log editing to the shared source
- add inline Day Context editing in Plan and Log with autosaved notes, tappable tag chips, and inline new-label creation
- extend the Log list to include metadata-only days and show selected day tags without note excerpts
- add Day Tags management in Data Manager with create, edit, recolor, reorder, soft-delete, and tap-to-edit row behavior
- leave CSV export/import unchanged

## Implementation Details
- Added DayLog and DayTag SwiftData models and registered them in the app/test containers.
- Added DayLogStore for normalized day fetch/create, note trimming, tag assignment, duplicate-name prevention, tag creation/renaming, and soft-delete cleanup.
- Added a run-once backfill from legacy PlanDay.dailyNotes into shared DayLog.note while preserving existing shared notes.
- Added LogDaySummaryBuilder so the Log list combines sessions, climbs, and metadata-only DayLog records.
- Added shared DayContextEditorSection and tag chip views for inline note editing, selected-first tag ordering, accessible chip toggles, and the compact New label input chip.
- Updated Plan day editor to stop writing PlanDay.dailyNotes directly and use shared DayLog note/tags.
- Updated Data Manager Day Tags so tapping a tag row opens the edit view in addition to the existing swipe/context menu edit action.

## Tests
- xcodebuild test -project ClimbingProgram.xcodeproj -scheme ClimbingProgram -destination 'platform=iOS Simulator,name=iPhone 17'
- xcodebuild build -project ClimbingProgram.xcodeproj -scheme ClimbingProgram -destination 'platform=iOS Simulator,name=iPhone 17'
- xcodebuild test -project ClimbingProgram.xcodeproj -scheme ClimbingProgram -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:ClimbingProgramTests/DayLogStoreTests