### PR TITLE
Fix persistence, day navigation, and TB2 refresh UX

### DIFF
--- a/ClimbingProgram/design/Theme.swift
+++ b/ClimbingProgram/design/Theme.swift
@@ -24,6 +24,27 @@ enum CatalogHue: String {
     }
 }
 
+enum CatalogColorResolver {
+    static func hueByExerciseName(from activities: [Activity]) -> [String: CatalogHue] {
+        var result: [String: CatalogHue] = [:]
+
+        for activity in activities {
+            for trainingType in activity.types {
+                for exercise in trainingType.exercises {
+                    result[exercise.name] = activity.hue
+                }
+                for combination in trainingType.combinations {
+                    for exercise in combination.exercises {
+                        result[exercise.name] = activity.hue
+                    }
+                }
+            }
+        }
+
+        return result
+    }
+}
+
 extension Activity {
     var hue: CatalogHue {
         let n = name.lowercased()

--- a/ClimbingProgram/features/catalog/CatalogView.swift
+++ b/ClimbingProgram/features/catalog/CatalogView.swift
@@ -7,6 +7,95 @@
 import SwiftUI
 import SwiftData
 
+struct CatalogExerciseDraft {
+    let name: String
+    let area: String
+    let reps: String
+    let sets: String
+    let duration: String
+    let rest: String
+    let notes: String
+    let description: String
+
+    private func optionalValue(_ value: String) -> String? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    var normalizedName: String {
+        name.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var normalizedArea: String? { optionalValue(area) }
+    var normalizedReps: String? { optionalValue(reps) }
+    var normalizedSets: String? { optionalValue(sets) }
+    var normalizedDuration: String? { optionalValue(duration) }
+    var normalizedRest: String? { optionalValue(rest) }
+    var normalizedNotes: String? { optionalValue(notes) }
+    var normalizedDescription: String? { optionalValue(description) }
+
+    func makeExercise(order: Int) -> Exercise {
+        Exercise(
+            name: normalizedName,
+            area: normalizedArea,
+            order: order,
+            exerciseDescription: normalizedDescription,
+            repsText: normalizedReps,
+            durationText: normalizedDuration,
+            setsText: normalizedSets,
+            restText: normalizedRest,
+            notes: normalizedNotes
+        )
+    }
+
+    func apply(to exercise: Exercise) {
+        exercise.name = normalizedName
+        exercise.area = normalizedArea
+        exercise.exerciseDescription = normalizedDescription
+        exercise.repsText = normalizedReps
+        exercise.setsText = normalizedSets
+        exercise.durationText = normalizedDuration
+        exercise.restText = normalizedRest
+        exercise.notes = normalizedNotes
+    }
+}
+
+enum CatalogExercisePersistence {
+    enum Error: Swift.Error, LocalizedError {
+        case exerciseNotFoundAfterSave(UUID)
+
+        var errorDescription: String? {
+            switch self {
+            case .exerciseNotFoundAfterSave(let id):
+                return "Exercise \(id) was not found after saving."
+            }
+        }
+    }
+
+    static func saveNew(_ exercise: Exercise, in context: ModelContext) throws {
+        context.insert(exercise)
+        try saveAndVerify(exercise, in: context, operation: "create")
+    }
+
+    static func saveExisting(_ exercise: Exercise, in context: ModelContext) throws {
+        try saveAndVerify(exercise, in: context, operation: "update")
+    }
+
+    private static func saveAndVerify(_ exercise: Exercise, in context: ModelContext, operation: String) throws {
+        do {
+            try context.save()
+            let id = exercise.id
+            let descriptor = FetchDescriptor<Exercise>(predicate: #Predicate { $0.id == id })
+            guard (try context.fetch(descriptor)).first != nil else {
+                throw Error.exerciseNotFoundAfterSave(id)
+            }
+        } catch {
+            print("Catalog exercise \(operation) failed for '\(exercise.name)': \(error.localizedDescription)")
+            throw error
+        }
+    }
+}
+
 // MARK: - Root Catalog (Categories = Activity)
 
 struct CatalogView: View {
@@ -445,19 +534,24 @@ struct TrainingTypeDetailView: View {
                     availableAreas: availableAreas
                 ) {
                     let nextOrder = (trainingType.exercises.map { $0.order }.max() ?? 0) + 1
-                    let ex = Exercise(
-                        name: draftExName.trimmingCharacters(in: .whitespaces),
-                        area: draftArea.isEmpty ? nil : draftArea,
-                        order: nextOrder,
-                        exerciseDescription: draftDescription.isEmpty ? nil : draftDescription,
-                        repsText: draftReps.isEmpty ? nil : draftReps,
-                        durationText: draftDuration.isEmpty ? nil : draftDuration,
-                        setsText: draftSets.isEmpty ? nil : draftSets,
-                        restText: draftRest.isEmpty ? nil : draftRest,
-                        notes: draftNotes.isEmpty ? nil : draftNotes
+                    let draft = CatalogExerciseDraft(
+                        name: draftExName,
+                        area: draftArea,
+                        reps: draftReps,
+                        sets: draftSets,
+                        duration: draftDuration,
+                        rest: draftRest,
+                        notes: draftNotes,
+                        description: draftDescription
                     )
+                    let ex = draft.makeExercise(order: nextOrder)
                     trainingType.exercises.append(ex)
-                    try? context.save()
+                    do {
+                        try CatalogExercisePersistence.saveNew(ex, in: context)
+                    } catch {
+                        trainingType.exercises.removeAll { $0.id == ex.id }
+                        context.delete(ex)
+                    }
                 }
             }
         }
@@ -476,15 +570,22 @@ struct TrainingTypeDetailView: View {
                 description: $draftDescription,
                 availableAreas: availableAreas
             ) {
-                ex.name = draftExName.trimmingCharacters(in: .whitespaces)
-                ex.area = draftArea.isEmpty ? nil : draftArea
-                ex.exerciseDescription = draftDescription.isEmpty ? nil : draftDescription
-                ex.repsText = draftReps.isEmpty ? nil : draftReps
-                ex.setsText = draftSets.isEmpty ? nil : draftSets
-                ex.durationText = draftSets.isEmpty ? nil : draftDuration
-                ex.restText = draftRest.isEmpty ? nil : draftRest
-                ex.notes = draftNotes.isEmpty ? nil : draftNotes
-                try? context.save()
+                let draft = CatalogExerciseDraft(
+                    name: draftExName,
+                    area: draftArea,
+                    reps: draftReps,
+                    sets: draftSets,
+                    duration: draftDuration,
+                    rest: draftRest,
+                    notes: draftNotes,
+                    description: draftDescription
+                )
+                draft.apply(to: ex)
+                do {
+                    try CatalogExercisePersistence.saveExisting(ex, in: context)
+                } catch {
+                    print("Catalog exercise update could not be committed: \(error.localizedDescription)")
+                }
             }
         }
     }
@@ -620,19 +721,24 @@ struct CombinationDetailView: View {
                     availableAreas: []
                 ) {
                     let nextOrder = (combo.exercises.map { $0.order }.max() ?? 0) + 1
-                    let ex = Exercise(
-                        name: draftExName.trimmingCharacters(in: .whitespaces),
-                        area: draftArea.isEmpty ? nil : draftArea,
-                        order: nextOrder,
-                        exerciseDescription: draftDesc.isEmpty ? nil : draftDesc,
-                        repsText: draftReps.isEmpty ? nil : draftReps,
-                        durationText: draftDuration.isEmpty ? nil : draftDuration,
-                        setsText: draftSets.isEmpty ? nil : draftSets,
-                        restText: draftRest.isEmpty ? nil : draftRest,
-                        notes: draftNotes.isEmpty ? nil : draftNotes
+                    let draft = CatalogExerciseDraft(
+                        name: draftExName,
+                        area: draftArea,
+                        reps: draftReps,
+                        sets: draftSets,
+                        duration: draftDuration,
+                        rest: draftRest,
+                        notes: draftNotes,
+                        description: draftDesc
                     )
+                    let ex = draft.makeExercise(order: nextOrder)
                     combo.exercises.append(ex)
-                    try? context.save()
+                    do {
+                        try CatalogExercisePersistence.saveNew(ex, in: context)
+                    } catch {
+                        combo.exercises.removeAll { $0.id == ex.id }
+                        context.delete(ex)
+                    }
                 }
             }
         }
@@ -651,15 +757,22 @@ struct CombinationDetailView: View {
                 description: $draftDesc,
                 availableAreas: []
             ) {
-                ex.name = draftExName.trimmingCharacters(in: .whitespaces)
-                ex.area = draftArea.isEmpty ? nil : draftArea
-                ex.exerciseDescription = draftDesc.isEmpty ? nil : draftDesc
-                ex.repsText = draftReps.isEmpty ? nil : draftReps
-                ex.setsText = draftSets.isEmpty ? nil : draftSets
-                ex.durationText = draftDuration.isEmpty ? nil : draftDuration
-                ex.restText = draftRest.isEmpty ? nil : draftRest
-                ex.notes = draftNotes.isEmpty ? nil : draftNotes
-                try? context.save()
+                let draft = CatalogExerciseDraft(
+                    name: draftExName,
+                    area: draftArea,
+                    reps: draftReps,
+                    sets: draftSets,
+                    duration: draftDuration,
+                    rest: draftRest,
+                    notes: draftNotes,
+                    description: draftDesc
+                )
+                draft.apply(to: ex)
+                do {
+                    try CatalogExercisePersistence.saveExisting(ex, in: context)
+                } catch {
+                    print("Catalog exercise update could not be committed: \(error.localizedDescription)")
+                }
             }
         }
     }

--- a/ClimbingProgram/features/climb/ClimbView.swift
+++ b/ClimbingProgram/features/climb/ClimbView.swift
@@ -77,6 +77,7 @@ struct ClimbView: View {
     @State private var isSyncStatusVisible = false
     @State private var canDismissSyncStatus = false
     @State private var syncProgressText = "Syncing…"
+    @State private var syncShowsLongCacheNotice = false
     @State private var syncShowsStepProgress = false
     @State private var activeSyncStep: SyncStep? = nil
     @State private var syncVisibleSteps = SyncStep.allCases
@@ -636,6 +637,7 @@ struct ClimbView: View {
         isSyncStatusVisible = false
         canDismissSyncStatus = false
         syncProgressText = "Syncing…"
+        syncShowsLongCacheNotice = false
         syncShowsStepProgress = false
         activeSyncStep = nil
         syncVisibleSteps = SyncStep.allCases
@@ -650,6 +652,18 @@ struct ClimbView: View {
 
     private var syncProgressOverlay: some View {
         VStack(alignment: .leading, spacing: 12) {
+            if syncShowsLongCacheNotice {
+                HStack(alignment: .top, spacing: 4) {
+                    Text("*")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                    Text("First refresh or one after 6+ months may take a little longer while the cache is rebuilt.")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+
             if syncShowsStepProgress {
                 VStack(spacing: 10) {
                     ForEach(syncVisibleSteps) { step in
@@ -741,6 +755,7 @@ struct ClimbView: View {
         isSyncStatusVisible = true
         canDismissSyncStatus = false
         syncProgressText = "Syncing…"
+        syncShowsLongCacheNotice = board == .tension && TB2SyncManager.cacheRefreshMayTakeLong(for: .tension)
         syncShowsStepProgress = false
         activeSyncStep = nil
         syncVisibleSteps = SyncStep.allCases

--- a/ClimbingProgram/features/climb/TB2SyncManager.swift
+++ b/ClimbingProgram/features/climb/TB2SyncManager.swift
@@ -39,6 +39,29 @@ enum TB2SyncManager {
 
     typealias ClimbStatsCacheState = ClimbCacheState
 
+    private static let longCacheRefreshIntervalMonths = 6
+
+    /// Returns whether the next TB2 refresh may need to rebuild a large cache.
+    /// Both metadata caches are required for the refreshed climb data to be complete.
+    static func cacheRefreshMayTakeLong(for board: TB2Client.Board, now: Date = Date()) -> Bool {
+        let calendar = Calendar(identifier: .gregorian)
+        guard let cutoff = calendar.date(
+            byAdding: .month,
+            value: -longCacheRefreshIntervalMonths,
+            to: now
+        ) else {
+            return true
+        }
+
+        return [climbCacheState(for: board), climbStatsCacheState(for: board)].contains { state in
+            guard state.isComplete, let lastSynchronizedAt = state.lastSynchronizedAt,
+                  let lastSyncDate = BoardDateParser.parse(lastSynchronizedAt) else {
+                return true
+            }
+            return lastSyncDate < cutoff
+        }
+    }
+
     struct DiffKey: Hashable {
         let uuid: String
         let angle: Int

--- a/ClimbingProgram/features/plans/PlansViews.swift
+++ b/ClimbingProgram/features/plans/PlansViews.swift
@@ -134,18 +134,28 @@ struct PlansListView: View {
 
     // Alerts
     @State private var resultMessage: String? = nil
+    @FocusState private var focusedDayContextField: DayContextFocusedField?
 
 
     var body: some View {
         NavigationStack(path: Binding(
             get: { timerAppState.plansNavigationPath },
-            set: { timerAppState.plansNavigationPath = $0 }
+            set: { newPath in
+                if newPath.count < timerAppState.plansNavigationPath.count {
+                    focusedDayContextField = nil
+                }
+                timerAppState.plansNavigationPath = newPath
+            }
         )) {
             plansList
                 .listStyle(.insetGrouped)
                 .navigationTitle("TRAIN")
                 .navigationBarTitleDisplayMode(.large)
-                .plansDestinations(plans: plans, timerAppState: timerAppState)
+                .plansDestinations(
+                    plans: plans,
+                    timerAppState: timerAppState,
+                    focusedDayContextField: $focusedDayContextField
+                )
                 .plansToolbar(
                     isDataReady: isDataReady,
                     context: context,
@@ -267,13 +277,17 @@ struct PlansListView: View {
 private struct PlansDestinationsModifier: ViewModifier {
     let plans: [Plan]
     let timerAppState: TimerAppState
+    let focusedDayContextField: FocusState<DayContextFocusedField?>.Binding
 
     func body(content: Content) -> some View {
         content
             .navigationDestination(for: PlanNavigationItem.self) { item in
                 // Resolve plan from current list to avoid relying on PlanNavigationItem's stored property name
                 if let plan = plans.first(where: { $0.id == item.planId }) {
-                    PlanDetailView(plan: plan)
+                    PlanDetailView(
+                        plan: plan,
+                        focusedDayContextField: focusedDayContextField
+                    )
                         .environment(timerAppState)
                 } else {
                     Text("Plan not found")
@@ -283,7 +297,10 @@ private struct PlansDestinationsModifier: ViewModifier {
                 if let plan = plans.first(where: { plan in
                     plan.days.contains(where: { $0.id == dayItem.planDayId })
                 }) {
-                    PlanDetailView(plan: plan)
+                    PlanDetailView(
+                        plan: plan,
+                        focusedDayContextField: focusedDayContextField
+                    )
                         .environment(timerAppState)
                 } else {
                     Text("Plan day not found")
@@ -293,8 +310,16 @@ private struct PlansDestinationsModifier: ViewModifier {
 }
 
 private extension View {
-    func plansDestinations(plans: [Plan], timerAppState: TimerAppState) -> some View {
-        modifier(PlansDestinationsModifier(plans: plans, timerAppState: timerAppState))
+    func plansDestinations(
+        plans: [Plan],
+        timerAppState: TimerAppState,
+        focusedDayContextField: FocusState<DayContextFocusedField?>.Binding
+    ) -> some View {
+        modifier(PlansDestinationsModifier(
+            plans: plans,
+            timerAppState: timerAppState,
+            focusedDayContextField: focusedDayContextField
+        ))
     }
 }
 
@@ -520,9 +545,14 @@ struct PlanDetailView: View {
     @Environment(\.modelContext) private var context
     @Environment(TimerAppState.self) private var timerAppState
     @State private var plan: Plan
+    let focusedDayContextField: FocusState<DayContextFocusedField?>.Binding
 
-    init(plan: Plan) {
+    init(
+        plan: Plan,
+        focusedDayContextField: FocusState<DayContextFocusedField?>.Binding
+    ) {
         _plan = State(initialValue: plan)
+        self.focusedDayContextField = focusedDayContextField
     }
 
     private enum ViewMode: Int {
@@ -730,11 +760,19 @@ struct PlanDetailView: View {
             }
             
         }
+        // Keep the view revealed by a back navigation at its full height while
+        // the outgoing editor's keyboard completes its native dismissal.
+        // The editor remains keyboard-aware because this applies only to the
+        // plan overview destination.
+        .ignoresSafeArea(.keyboard, edges: .bottom)
         .navigationTitle(plan.name)
         .navigationDestination(for: EditablePlanDayNav.self) { nav in
             if nav.planId == plan.id,
                let idx = plan.days.firstIndex(where: { $0.id == nav.planDayId }) {
-                PlanDayEditor(day: $plan.days[idx])
+                PlanDayEditor(
+                    day: $plan.days[idx],
+                    focusedDayContextField: focusedDayContextField
+                )
                     .environment(timerAppState)
             } else {
                 Text("Plan day not found")
@@ -781,6 +819,7 @@ struct PlanDayEditor: View {
     @Environment(TimerAppState.self) private var timerAppState
     @State private var didReorder = false
     @Binding var day: PlanDay
+    let focusedDayContextField: FocusState<DayContextFocusedField?>.Binding
 
     @Environment(\.modelContext) private var context
     @State private var cache: PlanDayEditorCache
@@ -819,8 +858,12 @@ struct PlanDayEditor: View {
     @State private var applyRecurringToExisting = true
     @State private var cloneMessage: String? = nil
 
-    init(day: Binding<PlanDay>) {
+    init(
+        day: Binding<PlanDay>,
+        focusedDayContextField: FocusState<DayContextFocusedField?>.Binding
+    ) {
         self._day = day
+        self.focusedDayContextField = focusedDayContextField
         self._cache = State(initialValue: PlanDayEditorCache.forDay(day.wrappedValue.id))
     }
     
@@ -1263,7 +1306,8 @@ struct PlanDayEditor: View {
         DayContextEditorSection(
             date: day.date,
             dayLog: localDayLog,
-            onDayLogChanged: updateDayLog
+            onDayLogChanged: updateDayLog,
+            focusedField: focusedDayContextField
         )
     }
 
@@ -1291,6 +1335,7 @@ struct PlanDayEditor: View {
             loggedExercisesSection
             dailyNotesSection
         }
+        .scrollDismissesKeyboard(.interactively)
         .navigationTitle(day.date.formatted(date: .abbreviated, time: .omitted))
         .listStyle(.insetGrouped)
         .onAppear {
@@ -1402,6 +1447,12 @@ struct PlanDayEditor: View {
         }
         .onChange(of: day.chosenExercises) {
             reconcileExerciseIDFields()
+            // The cache is intentionally reused while editing a day, but the
+            // catalog can change while the editor is open. Rebuild metadata
+            // before the next row render so newly selected exercises get
+            // their activity color immediately.
+            warmCachesIntoCache()
+            cache.isWarm = true
             try? context.save()
         }
         // Quick Progress sheet

--- a/ClimbingProgram/features/sessions/LogDaySummaryBuilder.swift
+++ b/ClimbingProgram/features/sessions/LogDaySummaryBuilder.swift
@@ -24,11 +24,14 @@ enum LogDaySummaryBuilder {
         var grouped: [Date: LogDaySummary] = [:]
 
         for session in sessions {
+            let exerciseCount = session.items.count
+            guard exerciseCount > 0 else { continue }
+
             let dateKey = calendar.startOfDay(for: session.date)
             if grouped[dateKey] == nil {
                 grouped[dateKey] = LogDaySummary()
             }
-            grouped[dateKey]?.exercises = Array(session.items).count
+            grouped[dateKey]?.exercises = exerciseCount
             grouped[dateKey]?.session = session
         }
 
@@ -43,9 +46,7 @@ enum LogDaySummaryBuilder {
 
         for dayLog in dayLogs where DayLogStore.hasContext(dayLog) {
             let dateKey = calendar.startOfDay(for: dayLog.date)
-            if grouped[dateKey] == nil {
-                grouped[dateKey] = LogDaySummary()
-            }
+            guard grouped[dateKey] != nil else { continue }
             grouped[dateKey]?.dayLog = dayLog
         }
 

--- a/ClimbingProgram/features/sessions/LogView.swift
+++ b/ClimbingProgram/features/sessions/LogView.swift
@@ -56,6 +56,7 @@ struct LogView: View {
 
     @State private var modalRoute: ModalRoute?
     @State private var navigationPath = NavigationPath()
+    @FocusState private var focusedDayContextField: DayContextFocusedField?
 
 
     // Export
@@ -73,8 +74,21 @@ struct LogView: View {
     @State private var resultMessage: String? = nil
 
     var body: some View {
-            NavigationStack(path: $navigationPath) {
-                CombinedLogList(sessions: sessions, climbEntries: climbEntries, dayLogs: dayLogs)
+            NavigationStack(path: Binding(
+                get: { navigationPath },
+                set: { newPath in
+                    if newPath.count < navigationPath.count {
+                        focusedDayContextField = nil
+                    }
+                    navigationPath = newPath
+                }
+            )) {
+                CombinedLogList(
+                    sessions: sessions,
+                    climbEntries: climbEntries,
+                    dayLogs: dayLogs,
+                    focusedDayContextField: $focusedDayContextField
+                )
                     .toolbar { trailingToolbar }
                     .sheet(isPresented: newSessionPresentedBinding) {
                         NewSessionSheet { createdDay in
@@ -101,7 +115,8 @@ struct LogView: View {
                             date: dayKey,
                             session: sessionForDay,
                             climbEntries: climbsForDay,
-                            dayLog: dayLogForDay
+                            dayLog: dayLogForDay,
+                            focusedDayContextField: $focusedDayContextField
                         )
                     }
             }
@@ -995,6 +1010,7 @@ private struct CombinedLogList: View {
     let sessions: [Session]
     let climbEntries: [ClimbEntry]
     let dayLogs: [DayLog]
+    let focusedDayContextField: FocusState<DayContextFocusedField?>.Binding
 
     @State private var showFilters = false
     @State private var dateRange = DateRange()
@@ -1045,7 +1061,8 @@ private struct CombinedLogList: View {
                         date: date,
                         session: dayData.session,
                         climbEntries: dayData.climbEntries,
-                        dayLog: dayData.dayLog
+                        dayLog: dayData.dayLog,
+                        focusedDayContextField: focusedDayContextField
                     )
                 } label: {
                     CombinedDayRow(
@@ -1349,6 +1366,7 @@ private struct CombinedDayDetailView: View {
     let session: Session?
     let climbEntries: [ClimbEntry]
     let dayLog: DayLog?
+    let focusedDayContextField: FocusState<DayContextFocusedField?>.Binding
     
     @State private var addRoute: AddRoute? = nil
     @State private var didReorder = false
@@ -1375,7 +1393,8 @@ private struct CombinedDayDetailView: View {
             DayContextEditorSection(
                 date: date,
                 dayLog: resolvedDayLog,
-                onDayLogChanged: updateDayLog
+                onDayLogChanged: updateDayLog,
+                focusedField: focusedDayContextField
             )
 
             // Exercises section
@@ -1452,6 +1471,7 @@ private struct CombinedDayDetailView: View {
                 }
             }
         }
+        .scrollDismissesKeyboard(.interactively)
         .listStyle(.insetGrouped)
         .navigationTitle(date.formatted(date: .abbreviated, time: .omitted))
         .navigationBarTitleDisplayMode(.inline)

--- a/ClimbingProgram/features/timer/TimerManager.swift
+++ b/ClimbingProgram/features/timer/TimerManager.swift
@@ -292,6 +292,7 @@ class TimerManager {
         currentPhase = .work
         refreshDerivedFlags()
         laps.removeAll()
+        lastLapTime = 0
         lastBeepSecondForSegment = [:]
         session = nil
         pausedAtDuringGetReady = false

--- a/ClimbingProgram/shared/DayContextViews.swift
+++ b/ClimbingProgram/shared/DayContextViews.swift
@@ -68,12 +68,19 @@ enum DayTagPresentationBuilder {
     }
 }
 
+enum DayContextFocusedField: Hashable {
+    case note
+    case newTag
+}
+
 struct DayContextEditorSection: View {
+
     @Environment(\.modelContext) private var context
 
     let date: Date
     let dayLog: DayLog?
     let onDayLogChanged: (DayLog?) -> Void
+    let focusedField: FocusState<DayContextFocusedField?>.Binding
 
     @Query(
         filter: #Predicate<DayTag> { $0.isHidden == false },
@@ -87,7 +94,6 @@ struct DayContextEditorSection: View {
     @State private var newTagName = ""
     @State private var newTagColorKey = "gray"
     @State private var errorMessage: String?
-    @FocusState private var isNewTagFocused: Bool
 
     private var selectedTags: [DayTag] {
         DayLogStore.activeTags(from: dayLog)
@@ -102,13 +108,26 @@ struct DayContextEditorSection: View {
     }
 
     private var shouldShowNewTagControls: Bool {
-        isNewTagFocused || !trimmedNewTagName.isEmpty
+        focusedField.wrappedValue == .newTag || !trimmedNewTagName.isEmpty
     }
 
     var body: some View {
         Section("Day Context") {
-            TextField("Daily note", text: $noteText, axis: .vertical)
-                .lineLimit(2...6)
+            TextEditor(text: $noteText)
+                .frame(height: 120)
+                .scrollIndicators(.visible, axes: .vertical)
+                .scrollDismissesKeyboard(.interactively)
+                .focused(focusedField, equals: .note)
+                .accessibilityLabel("Daily note")
+                .overlay(alignment: .topLeading) {
+                    if noteText.isEmpty {
+                        Text("Daily note")
+                            .foregroundStyle(.tertiary)
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 8)
+                            .allowsHitTesting(false)
+                    }
+                }
                 .onChange(of: noteText) { _, _ in
                     saveNote()
                 }
@@ -129,7 +148,7 @@ struct DayContextEditorSection: View {
                     }
 
                     NewLabelChip(name: $newTagName, colorKey: newTagColorKey)
-                        .focused($isNewTagFocused)
+                        .focused(focusedField, equals: .newTag)
                         .onSubmit(addTag)
                 }
 
@@ -147,7 +166,11 @@ struct DayContextEditorSection: View {
             syncNoteText()
         }
         .onChange(of: date) { _, _ in
+            focusedField.wrappedValue = nil
             syncNoteText()
+        }
+        .onDisappear {
+            focusedField.wrappedValue = nil
         }
         .alert(errorMessage ?? "", isPresented: Binding(
             get: { errorMessage != nil },
@@ -209,7 +232,7 @@ struct DayContextEditorSection: View {
     private func resetNewTagInput() {
         newTagName = ""
         newTagColorKey = "gray"
-        isNewTagFocused = false
+        focusedField.wrappedValue = nil
     }
 
     private func addTag() {

--- a/ClimbingProgramTests/BusinessLogicTests.swift
+++ b/ClimbingProgramTests/BusinessLogicTests.swift
@@ -366,6 +366,54 @@ class BusinessLogicTests: ClimbingProgramTestSuite {
         XCTAssertEqual(state.lastSynchronizedAt, "2026-01-02 00:00:00.000000")
     }
 
+    func testTB2CacheRefreshMayTakeLongForFirstRefresh() {
+        clearTB2CacheRefreshState()
+        defer { clearTB2CacheRefreshState() }
+
+        XCTAssertTrue(TB2SyncManager.cacheRefreshMayTakeLong(for: .tension, now: Date(timeIntervalSince1970: 1_800_000_000)))
+    }
+
+    func testTB2CacheRefreshMayTakeLongWhenEitherCacheIsOlderThanSixMonths() {
+        clearTB2CacheRefreshState()
+        defer { clearTB2CacheRefreshState() }
+
+        UserDefaults.standard.set(true, forKey: "tb2.climbsCache.tension.complete")
+        UserDefaults.standard.set("2026-01-02 00:00:00.000000", forKey: "tb2.climbsCache.tension.lastSynchronizedAt")
+        UserDefaults.standard.set(true, forKey: "tb2.climbStatsCache.tension.complete")
+        UserDefaults.standard.set("2025-01-01 00:00:00.000000", forKey: "tb2.climbStatsCache.tension.lastSynchronizedAt")
+
+        guard let now = BoardDateParser.parse("2026-08-04 00:00:00.000000") else {
+            return XCTFail("Expected test date to parse")
+        }
+        XCTAssertTrue(TB2SyncManager.cacheRefreshMayTakeLong(for: .tension, now: now))
+    }
+
+    func testTB2CacheRefreshDoesNotWarnForRecentCompleteCaches() {
+        clearTB2CacheRefreshState()
+        defer { clearTB2CacheRefreshState() }
+
+        UserDefaults.standard.set(true, forKey: "tb2.climbsCache.tension.complete")
+        UserDefaults.standard.set("2026-07-01 00:00:00.000000", forKey: "tb2.climbsCache.tension.lastSynchronizedAt")
+        UserDefaults.standard.set(true, forKey: "tb2.climbStatsCache.tension.complete")
+        UserDefaults.standard.set("2026-07-01 00:00:00.000000", forKey: "tb2.climbStatsCache.tension.lastSynchronizedAt")
+
+        guard let now = BoardDateParser.parse("2026-08-04 00:00:00.000000") else {
+            return XCTFail("Expected test date to parse")
+        }
+        XCTAssertFalse(TB2SyncManager.cacheRefreshMayTakeLong(for: .tension, now: now))
+    }
+
+    private func clearTB2CacheRefreshState() {
+        for key in [
+            "tb2.climbsCache.tension.complete",
+            "tb2.climbsCache.tension.lastSynchronizedAt",
+            "tb2.climbStatsCache.tension.complete",
+            "tb2.climbStatsCache.tension.lastSynchronizedAt"
+        ] {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+    }
+
     @MainActor
     func testTB2ClimbStatsMetadataCacheInsertsAndUpdatesRows() throws {
         let initial = TB2Client.SyncResponse(

--- a/ClimbingProgramTests/CatalogPersistenceTests.swift
+++ b/ClimbingProgramTests/CatalogPersistenceTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+import SwiftData
+@testable import klettrack
+
+@MainActor
+final class CatalogPersistenceTests: BaseSwiftDataTestCase {
+    func testNewExercisePersistsAllDisplayFieldsAcrossRefetch() throws {
+        let activity = createTestActivity(name: "Core")
+        let trainingType = createTestTrainingType(activity: activity, name: "Test Type")
+        let draft = CatalogExerciseDraft(
+            name: "  Timed Set  ",
+            area: "",
+            reps: "8-10",
+            sets: "3",
+            duration: "45 sec",
+            rest: "2 min",
+            notes: "controlled",
+            description: "test exercise"
+        )
+        let exercise = draft.makeExercise(order: 1)
+        trainingType.exercises.append(exercise)
+
+        try CatalogExercisePersistence.saveNew(exercise, in: context)
+
+        let reloadedContext = ModelContext(container)
+        let descriptor = FetchDescriptor<Exercise>(
+            predicate: #Predicate { $0.name == "Timed Set" }
+        )
+        let reloaded = try XCTUnwrap(try reloadedContext.fetch(descriptor).first)
+
+        XCTAssertEqual(reloaded.repsText, "8-10")
+        XCTAssertEqual(reloaded.setsText, "3")
+        XCTAssertEqual(reloaded.durationText, "45 sec")
+        XCTAssertEqual(reloaded.restText, "2 min")
+        XCTAssertEqual(reloaded.notes, "controlled")
+        XCTAssertEqual(reloaded.exerciseDescription, "test exercise")
+    }
+
+    func testEditingExercisePersistsDurationWhenSetsAreEmpty() throws {
+        let exercise = Exercise(name: "Existing", setsText: "3", durationText: "10 sec")
+        context.insert(exercise)
+        try context.save()
+
+        let draft = CatalogExerciseDraft(
+            name: "Existing",
+            area: "",
+            reps: "",
+            sets: "",
+            duration: "60 sec",
+            rest: "90 sec",
+            notes: "",
+            description: ""
+        )
+        draft.apply(to: exercise)
+        try CatalogExercisePersistence.saveExisting(exercise, in: context)
+
+        let descriptor = FetchDescriptor<Exercise>(
+            predicate: #Predicate { $0.id == exercise.id }
+        )
+        let reloaded = try XCTUnwrap(try context.fetch(descriptor).first)
+        XCTAssertNil(reloaded.setsText)
+        XCTAssertEqual(reloaded.durationText, "60 sec")
+        XCTAssertEqual(reloaded.restText, "90 sec")
+    }
+
+    func testCatalogColorResolverFindsExerciseAddedAfterWarmSnapshot() {
+        let activity = createTestActivity(name: "Core")
+        let trainingType = createTestTrainingType(activity: activity, name: "Test Type")
+        let initial = Exercise(name: "Initial")
+        trainingType.exercises.append(initial)
+
+        let warmSnapshot = CatalogColorResolver.hueByExerciseName(from: [activity])
+        XCTAssertEqual(warmSnapshot["Initial"], .core)
+        XCTAssertNil(warmSnapshot["Added Later"])
+
+        trainingType.exercises.append(Exercise(name: "Added Later"))
+        let refreshedSnapshot = CatalogColorResolver.hueByExerciseName(from: [activity])
+
+        XCTAssertEqual(refreshedSnapshot["Added Later"], .core)
+    }
+}

--- a/ClimbingProgramTests/DayLogStoreTests.swift
+++ b/ClimbingProgramTests/DayLogStoreTests.swift
@@ -127,40 +127,59 @@ final class DayLogStoreTests: BaseSwiftDataTestCase {
         XCTAssertEqual(dayLog.note, "Existing shared note")
     }
 
-    func testLogSummaryIncludesActivityOnlyMetadataOnlyAndMixedDays() throws {
+    func testLogSummaryOnlyIncludesDaysWithLoggedActivity() throws {
         let calendar = Calendar.current
-        let activityOnlyDay = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 7, day: 24, hour: 10)))
+        let exerciseOnlyDay = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 7, day: 24, hour: 10)))
         let metadataOnlyDay = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 7, day: 25, hour: 10)))
         let mixedDay = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 7, day: 26, hour: 10)))
+        let emptySessionDay = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 7, day: 27, hour: 10)))
+        let climbOnlyDay = try XCTUnwrap(calendar.date(from: DateComponents(year: 2026, month: 7, day: 28, hour: 10)))
 
-        let activitySession = createTestSession(date: activityOnlyDay)
-        activitySession.items.append(SessionItem(exerciseName: "Rows"))
+        let exerciseSession = createTestSession(date: exerciseOnlyDay)
+        exerciseSession.items.append(SessionItem(exerciseName: "Rows"))
 
         let metadataOnlyLog = try XCTUnwrap(DayLogStore.dayLog(for: metadataOnlyDay, in: context))
         metadataOnlyLog.note = "Travel day"
 
+        let emptySession = createTestSession(date: emptySessionDay)
+
+        let climb = ClimbEntry(
+            climbType: .boulder,
+            grade: "6A",
+            style: "",
+            gym: "",
+            dateLogged: climbOnlyDay
+        )
+        context.insert(climb)
+
         let mixedSession = createTestSession(date: mixedDay)
         mixedSession.items.append(SessionItem(exerciseName: "Pullups"))
         let mixedLog = try XCTUnwrap(DayLogStore.dayLog(for: mixedDay, in: context))
+        mixedLog.note = "High volume"
         let tag = try XCTUnwrap(DayLogStore.createTag(name: "Volume", colorKey: "green", in: context))
         DayLogStore.setTag(tag, assigned: true, to: mixedLog)
 
         let grouped = LogDaySummaryBuilder.build(
-            sessions: [activitySession, mixedSession],
-            climbEntries: [],
+            sessions: [exerciseSession, mixedSession, emptySession],
+            climbEntries: [climb],
             dayLogs: [metadataOnlyLog, mixedLog],
             calendar: calendar
         )
 
-        let activityKey = calendar.startOfDay(for: activityOnlyDay)
+        let exerciseKey = calendar.startOfDay(for: exerciseOnlyDay)
         let metadataKey = calendar.startOfDay(for: metadataOnlyDay)
         let mixedKey = calendar.startOfDay(for: mixedDay)
+        let emptySessionKey = calendar.startOfDay(for: emptySessionDay)
+        let climbKey = calendar.startOfDay(for: climbOnlyDay)
 
-        XCTAssertEqual(grouped[activityKey]?.exercises, 1)
-        XCTAssertNil(grouped[activityKey]?.dayLog)
-        XCTAssertEqual(grouped[metadataKey]?.dayLog?.note, "Travel day")
-        XCTAssertEqual(grouped[metadataKey]?.exercises, 0)
+        XCTAssertEqual(grouped[exerciseKey]?.exercises, 1)
+        XCTAssertNil(grouped[exerciseKey]?.dayLog)
+        XCTAssertNil(grouped[metadataKey])
+        XCTAssertNil(grouped[emptySessionKey])
+        XCTAssertEqual(grouped[climbKey]?.climbs, 1)
+        XCTAssertEqual(grouped[climbKey]?.climbEntries.map(\.id), [climb.id])
         XCTAssertEqual(grouped[mixedKey]?.exercises, 1)
+        XCTAssertEqual(grouped[mixedKey]?.dayLog?.note, "High volume")
         XCTAssertEqual(DayLogStore.activeTags(from: grouped[mixedKey]?.dayLog).map(\.name), ["Volume"])
     }
 

--- a/ClimbingProgramTests/TimerManagerTests.swift
+++ b/ClimbingProgramTests/TimerManagerTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import klettrack
+
+@MainActor
+final class TimerManagerTests: XCTestCase {
+    func testRestartClearsDurationTimerLapBaseline() {
+        let manager = TimerManager()
+        manager.loadConfiguration(TimerConfiguration(totalTimeSeconds: 120))
+
+        // Simulate a completed duration timer after a lap was recorded.
+        manager.totalElapsedTime = 120
+        manager.addLap()
+        XCTAssertEqual(manager.displayTime, 0)
+
+        manager.restart()
+
+        XCTAssertEqual(manager.totalElapsedTime, 0)
+        XCTAssertEqual(manager.displayTime, 0)
+        XCTAssertGreaterThanOrEqual(manager.displayTime, 0)
+    }
+}


### PR DESCRIPTION
### Changes

* **Tension Board refresh**

  * Show a notice when a TB2 refresh may take longer because the local cache needs to be rebuilt.
  * The notice appears on the first refresh or when either required cache has not been successfully refreshed for 6+ months.
  * Added tests covering first refresh, stale caches, and recently refreshed caches.

* **Exercise catalog**

  * Fix persistence of newly created and edited exercises.
  * Normalize optional exercise fields before saving.
  * Verify exercises can be fetched after saving and clean up failed inserts.
  * Fix duration being lost when an exercise has no sets configured.
  * Refresh exercise/activity color mappings so newly added exercises immediately use the correct color.
  * Added persistence and color-resolution tests.

* **Plan navigation**

  * Improve keyboard/focus handling when navigating back from a plan day.
  * Clear active Day Context fields when navigating away from an editor.
  * Prevent the previous screen from resizing while the keyboard is being dismissed.
  * Refresh cached exercise metadata when selected exercises change so activity colors update immediately.

* **Log & Day Context**

  * Only include days with actual logged activity in the Log overview; notes/tags alone no longer create a log entry.
  * Ignore empty sessions when building daily log summaries.
  * Improve Day Context note editing with a larger scrollable editor.
  * Improve keyboard dismissal and focus handling for notes and new tags across plan and log navigation.

* **timer total duration bug**

  * Reset lastLapTime during timer restart to avoid negative counting

## Test coverage

Added or updated tests for:

* TB2 long-refresh detection
* Exercise creation/edit persistence
* Exercise color refresh
* Log summary filtering and grouping
