### PR TITLE
feat: add plan CSV exchange and catalog reassignment

### DIFF
--- a/ClimbingProgram/app/ClimbingProgramApp.swift
+++ b/ClimbingProgram/app/ClimbingProgramApp.swift
@@ -17,10 +17,11 @@ struct ClimbingProgramApp: App {
                 }
         }
         .modelContainer(for: [
-            Activity.self, TrainingType.self, Exercise.self,
+            Activity.self, TrainingType.self, BoulderCombination.self, Exercise.self,
             Session.self, SessionItem.self,
             DayLog.self, DayTag.self,
-            Plan.self, PlanDay.self,
+            Plan.self, PlanDay.self, PlanKindModel.self, DayTypeModel.self,
+            PlanExerciseDefinition.self,
             TimerTemplate.self, TimerInterval.self, TimerSession.self, TimerLap.self,
             ClimbEntry.self, ClimbStyle.self, ClimbGym.self, ClimbMedia.self,
             TB2ClimbMetadata.self, TB2ClimbStatsMetadata.self

--- a/ClimbingProgram/data/io/PlanCSVExchange.swift
+++ b/ClimbingProgram/data/io/PlanCSVExchange.swift
@@ -793,7 +793,7 @@ private enum PlanCSVCodec {
             if character == "\"" {
                 current.append(character)
                 if quoted, index + 1 < chars.count, chars[index + 1] == "\"" { current.append(chars[index + 1]); index += 1 } else { quoted.toggle() }
-            } else if (character == "\n" || character == "\r") && !quoted {
+            } else if character.isNewline && !quoted {
                 if !current.isEmpty { result.append(current); current = "" }
                 if character == "\r", index + 1 < chars.count, chars[index + 1] == "\n" { index += 1 }
             } else { current.append(character) }

--- a/ClimbingProgram/data/io/PlanCSVExchange.swift
+++ b/ClimbingProgram/data/io/PlanCSVExchange.swift
@@ -680,7 +680,6 @@ enum PlanCSVExchange {
     private static func applyContexts(_ rows: [ParsedExchange.ContextRow], in context: ModelContext) {
         for row in rows {
             let existing = DayLogStore.fetchDayLog(for: row.date, in: context)
-            if let existing, DayLogStore.hasContext(existing) { continue }
             let dayLog = existing ?? DayLogStore.dayLog(for: row.date, in: context)
             guard let dayLog else { continue }
             DayLogStore.setNote(row.note ?? "", for: dayLog)

--- a/ClimbingProgram/data/io/PlanCSVExchange.swift
+++ b/ClimbingProgram/data/io/PlanCSVExchange.swift
@@ -34,16 +34,48 @@ enum PlanCSVExchange {
         case existing(Plan)
     }
 
-    struct Summary: Sendable {
+    struct ImportPreview: Sendable {
+        let isNewPlan: Bool
+        let planName: String
+        let targetPlanName: String
+        let metadataChanges: [String]
+        let daysToAdd: Int
+        let daysToUpdate: Int
+        let daysToRemove: Int
+        let protectedDayCount: Int
+        let scheduleEntriesToAdd: Int
+        let scheduleEntriesToRemove: Int
+        let exerciseDefinitionsToAdd: Int
+        let exerciseDefinitionsToUpdate: Int
+        let protectedLoggedExerciseCount: Int
+        let logsToImport: Int
+        let existingLogCount: Int
+        let climbsToImport: Int
+        let existingClimbCount: Int
+        let dayContextRows: Int
+        let dayContextRowsToApply: Int
+        let dayContextRowsIgnored: Int
+        let missingCatalogExerciseCount: Int
+        let warnings: [String]
+    }
+
+    struct Summary: Identifiable, Sendable {
+        let id = UUID()
         let planName: String
         let dayCount: Int
         let exerciseCount: Int
         let logCount: Int
         let climbCount: Int
+        let preview: ImportPreview
+        let existingLogCount: Int
+        let existingClimbCount: Int
+        let dayContextCountApplied: Int
+        let dayContextCountIgnored: Int
         let warnings: [String]
 
         var message: String {
-            var result = "Imported \(planName): \(dayCount) day(s), \(exerciseCount) exercise definition(s), \(logCount) log(s), \(climbCount) climb(s)."
+            let action = preview.isNewPlan ? "Created" : "Updated"
+            var result = "\(action) \(planName): \(preview.daysToAdd) day(s) added, \(preview.daysToUpdate) updated, \(preview.daysToRemove) removed; \(logCount) log(s) and \(climbCount) climb(s) imported."
             if !warnings.isEmpty {
                 result += " \(warnings.count) row warning(s)."
             }
@@ -314,6 +346,123 @@ enum PlanCSVExchange {
         return PlanCSVDocument(csv: rows.joined(separator: "\n"))
     }
 
+    static func preview(
+        _ exchange: ParsedExchange,
+        mode: ImportMode,
+        overwriteDayContext: Bool,
+        in context: ModelContext
+    ) -> ImportPreview {
+        let targetPlan: Plan? = switch mode {
+        case .newPlan: nil
+        case .existing(let plan): plan
+        }
+        let isNewPlan = targetPlan == nil
+        let targetPlanName = targetPlan?.name ?? exchange.plan.name
+        var metadataChanges: [String] = []
+        if let targetPlan {
+            if targetPlan.name != exchange.plan.name { metadataChanges.append("Plan name") }
+            if targetPlan.startDate != exchange.plan.startDate { metadataChanges.append("Start date") }
+            if targetPlan.kind?.key != exchange.plan.kindKey { metadataChanges.append("Plan kind") }
+        }
+
+        let calendar = Calendar.current
+        let persistedExercises = (try? context.fetch(FetchDescriptor<Exercise>())) ?? []
+        let targetDefinitions = targetPlan?.exerciseDefinitions ?? []
+        let currentSessions = (try? context.fetch(FetchDescriptor<Session>())) ?? []
+        let currentItems = targetPlan.map { plan in
+            currentSessions.flatMap(\.items).filter { $0.planSourceId == plan.id }
+        } ?? []
+        let currentClimbs = targetPlan.map { plan in
+            ((try? context.fetch(FetchDescriptor<ClimbEntry>())) ?? []).filter { $0.planSourceId == plan.id }
+        } ?? []
+
+        let targetDays = targetPlan?.days ?? []
+        let matchedDays = exchange.days.compactMap { row in
+            matchingDay(for: row, in: targetDays, calendar: calendar)
+        }
+        let matchedDayIDs = Set(matchedDays.map(\.id))
+        let daysToAdd = isNewPlan ? exchange.days.count : exchange.days.count - matchedDays.count
+        let daysToUpdate = isNewPlan ? 0 : matchedDays.count
+        let daysToRemove = isNewPlan ? 0 : targetDays.filter { day in
+            guard !matchedDayIDs.contains(day.id) else { return false }
+            return !hasProtectedRecords(on: day, items: currentItems, climbs: currentClimbs, in: currentSessions, calendar: calendar)
+        }.count
+        let protectedDayCount = targetDays.filter {
+            hasProtectedRecords(on: $0, items: currentItems, climbs: currentClimbs, in: currentSessions, calendar: calendar)
+        }.count
+
+        let definitionsByID = Dictionary(uniqueKeysWithValues: targetDefinitions.map { ($0.id, $0) })
+        let definitionsByName = Dictionary(targetDefinitions.map { (normalized($0.name), $0) }, uniquingKeysWith: { first, _ in first })
+        let incomingDefinitionsByID = Dictionary(uniqueKeysWithValues: exchange.exercises.map { ($0.id, $0) })
+        let exerciseDefinitionsToAdd = exchange.exercises.filter { row in
+            matchingDefinition(for: row, byID: definitionsByID, byName: definitionsByName) == nil
+        }.count
+        let exerciseDefinitionsToUpdate = exchange.exercises.compactMap { row -> PlanExerciseDefinition? in
+            matchingDefinition(for: row, byID: definitionsByID, byName: definitionsByName)
+        }.filter { definition in
+            guard let row = exchange.exercises.first(where: { $0.id == definition.id })
+                ?? exchange.exercises.first(where: { normalized($0.name) == normalized(definition.name) }) else { return false }
+            return definitionNeedsUpdate(definition, from: row)
+        }.count
+
+        var scheduleEntriesToAdd = 0
+        var scheduleEntriesToRemove = 0
+        if isNewPlan {
+            scheduleEntriesToAdd = exchange.days.reduce(0) { $0 + $1.exerciseRefs.count }
+        } else {
+            for row in exchange.days {
+                guard let targetDay = matchingDay(for: row, in: targetDays, calendar: calendar) else { continue }
+                let incomingNames = row.exerciseRefs.compactMap { incomingDefinitionsByID[$0.0]?.name }
+                let incomingNamesByNormalized = Set(incomingNames.map(normalized))
+                let existingNamesByNormalized = Set(targetDay.chosenExercises.map(normalized))
+                let loggedNames = Set(currentItems.filter {
+                    itemBelongs(to: targetDay, item: $0, sessions: currentSessions, calendar: calendar)
+                }.map { normalized($0.exerciseName) })
+                scheduleEntriesToAdd += incomingNames.filter { !existingNamesByNormalized.contains(normalized($0)) }.count
+                scheduleEntriesToRemove += targetDay.chosenExercises.filter {
+                    let normalizedName = normalized($0)
+                    return !incomingNamesByNormalized.contains(normalizedName) && !loggedNames.contains(normalizedName)
+                }.count
+            }
+        }
+
+        let existingLogIDs = Set(currentSessions.flatMap(\.items).map(\.id))
+        let allClimbs = (try? context.fetch(FetchDescriptor<ClimbEntry>())) ?? []
+        let existingClimbIDs = Set(allClimbs.map(\.id))
+        let existingLogCount = isNewPlan ? 0 : exchange.logs.filter { existingLogIDs.contains($0.id) }.count
+        let existingClimbCount = isNewPlan ? 0 : exchange.climbs.filter { existingClimbIDs.contains($0.id) }.count
+        let missingCatalogExerciseCount = exchange.exercises.filter { row in
+            let hasCatalogID = row.catalogID.map { catalogID in persistedExercises.contains { $0.id == catalogID } } ?? false
+            let hasNameMatch = persistedExercises.contains { normalized($0.name) == normalized(row.name) }
+            return !hasCatalogID && !hasNameMatch
+        }.count
+
+        return ImportPreview(
+            isNewPlan: isNewPlan,
+            planName: exchange.plan.name,
+            targetPlanName: targetPlanName,
+            metadataChanges: metadataChanges,
+            daysToAdd: daysToAdd,
+            daysToUpdate: daysToUpdate,
+            daysToRemove: daysToRemove,
+            protectedDayCount: protectedDayCount,
+            scheduleEntriesToAdd: scheduleEntriesToAdd,
+            scheduleEntriesToRemove: scheduleEntriesToRemove,
+            exerciseDefinitionsToAdd: isNewPlan ? exchange.exercises.count : exerciseDefinitionsToAdd,
+            exerciseDefinitionsToUpdate: isNewPlan ? 0 : exerciseDefinitionsToUpdate,
+            protectedLoggedExerciseCount: isNewPlan ? 0 : currentItems.count,
+            logsToImport: isNewPlan ? exchange.logs.count : exchange.logs.count - existingLogCount,
+            existingLogCount: existingLogCount,
+            climbsToImport: isNewPlan ? exchange.climbs.count : exchange.climbs.count - existingClimbCount,
+            existingClimbCount: existingClimbCount,
+            dayContextRows: exchange.contexts.count,
+            dayContextRowsToApply: overwriteDayContext ? exchange.contexts.count : 0,
+            dayContextRowsIgnored: overwriteDayContext ? 0 : exchange.contexts.count,
+            missingCatalogExerciseCount: missingCatalogExerciseCount,
+            warnings: exchange.warnings
+        )
+    }
+
     static func parse(_ csv: String) throws -> ParsedExchange {
         let records = PlanCSVCodec.records(csv)
         guard let headerRecord = records.first else { throw Error.emptyFile }
@@ -454,6 +603,7 @@ enum PlanCSVExchange {
         overwriteDayContext: Bool = false,
         in context: ModelContext
     ) throws -> Summary {
+        let importPreview = preview(exchange, mode: mode, overwriteDayContext: overwriteDayContext, in: context)
         let targetPlan: Plan
         let isNew: Bool
         switch mode {
@@ -610,6 +760,11 @@ enum PlanCSVExchange {
             exerciseCount: exchange.exercises.count,
             logCount: insertedLogs,
             climbCount: insertedClimbs,
+            preview: importPreview,
+            existingLogCount: importPreview.existingLogCount,
+            existingClimbCount: importPreview.existingClimbCount,
+            dayContextCountApplied: overwriteDayContext ? exchange.contexts.count : 0,
+            dayContextCountIgnored: overwriteDayContext ? 0 : exchange.contexts.count,
             warnings: exchange.warnings
         )
     }
@@ -745,6 +900,61 @@ enum PlanCSVExchange {
             }
         }
         return result
+    }
+
+    private static func matchingDay(
+        for row: ParsedExchange.DayRow,
+        in days: [PlanDay],
+        calendar: Calendar
+    ) -> PlanDay? {
+        days.first(where: { $0.id == row.id })
+            ?? days.first(where: { calendar.startOfDay(for: $0.date) == calendar.startOfDay(for: row.date) })
+    }
+
+    private static func itemBelongs(
+        to day: PlanDay,
+        item: SessionItem,
+        sessions: [Session],
+        calendar: Calendar
+    ) -> Bool {
+        if let planDayID = item.planDayId {
+            return planDayID == day.id
+        }
+        return sessionsDate(for: item, in: sessions, calendar: calendar) == calendar.startOfDay(for: day.date)
+    }
+
+    private static func hasProtectedRecords(
+        on day: PlanDay,
+        items: [SessionItem],
+        climbs: [ClimbEntry],
+        in sessions: [Session],
+        calendar: Calendar
+    ) -> Bool {
+        items.contains { itemBelongs(to: day, item: $0, sessions: sessions, calendar: calendar) }
+            || climbs.contains { calendar.startOfDay(for: $0.dateLogged) == calendar.startOfDay(for: day.date) }
+    }
+
+    private static func matchingDefinition(
+        for row: ParsedExchange.ExerciseRow,
+        byID definitionsByID: [UUID: PlanExerciseDefinition],
+        byName definitionsByName: [String: PlanExerciseDefinition]
+    ) -> PlanExerciseDefinition? {
+        definitionsByID[row.id] ?? definitionsByName[normalized(row.name)]
+    }
+
+    private static func definitionNeedsUpdate(
+        _ definition: PlanExerciseDefinition,
+        from row: ParsedExchange.ExerciseRow
+    ) -> Bool {
+        definition.catalogExerciseID != row.catalogID
+            || definition.name != row.name
+            || definition.area != row.area
+            || definition.exerciseDescription != row.description
+            || definition.repsText != row.reps
+            || definition.setsText != row.sets
+            || definition.durationText != row.duration
+            || definition.restText != row.rest
+            || definition.notes != row.notes
     }
 
     private static func sessionsDate(for item: SessionItem, in sessions: [Session], calendar: Calendar) -> Date? {

--- a/ClimbingProgram/data/io/PlanCSVExchange.swift
+++ b/ClimbingProgram/data/io/PlanCSVExchange.swift
@@ -733,7 +733,12 @@ enum PlanCSVExchange {
         return all.joined(separator: ",")
     }
 
-    private static func normalizedHeader(_ value: String) -> String { value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+    private static func normalizedHeader(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\u{FEFF}", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+    }
 
     private static func normalized(_ value: String) -> String { value.trimmingCharacters(in: .whitespacesAndNewlines).folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current) }
     private static func twoDigit(_ value: Int) -> String { value < 10 ? "0\(value)" : String(value) }

--- a/ClimbingProgram/data/io/PlanCSVExchange.swift
+++ b/ClimbingProgram/data/io/PlanCSVExchange.swift
@@ -1,0 +1,801 @@
+import Foundation
+import SwiftUI
+import SwiftData
+import UniformTypeIdentifiers
+import CryptoKit
+
+struct PlanCSVDocument: FileDocument {
+    static var readableContentTypes: [UTType] { [.commaSeparatedText] }
+    static var writableContentTypes: [UTType] { [.commaSeparatedText] }
+
+    var csv: String
+
+    init(csv: String = "") {
+        self.csv = csv
+    }
+
+    init(configuration: ReadConfiguration) throws {
+        guard let data = configuration.file.regularFileContents,
+              let csv = String(data: data, encoding: .utf8) else {
+            throw CocoaError(.fileReadCorruptFile)
+        }
+        self.csv = csv
+    }
+
+    func fileWrapper(configuration: WriteConfiguration) throws -> FileWrapper {
+        FileWrapper(regularFileWithContents: Data(csv.utf8))
+    }
+}
+
+@MainActor
+enum PlanCSVExchange {
+    enum ImportMode {
+        case newPlan
+        case existing(Plan)
+    }
+
+    struct Summary: Sendable {
+        let planName: String
+        let dayCount: Int
+        let exerciseCount: Int
+        let logCount: Int
+        let climbCount: Int
+        let warnings: [String]
+
+        var message: String {
+            var result = "Imported \(planName): \(dayCount) day(s), \(exerciseCount) exercise definition(s), \(logCount) log(s), \(climbCount) climb(s)."
+            if !warnings.isEmpty {
+                result += " \(warnings.count) row warning(s)."
+            }
+            return result
+        }
+    }
+
+    struct ParsedExchange: Sendable {
+        struct PlanRow: Sendable {
+            var id: UUID
+            var name: String
+            var startDate: Date
+            var kindKey: String?
+            var kindName: String?
+            var totalWeeks: Int?
+            var isRepeating: Bool
+        }
+
+        struct ExerciseRow: Sendable {
+            var id: UUID
+            var catalogID: UUID?
+            var name: String
+            var area: String?
+            var description: String?
+            var reps: String?
+            var sets: String?
+            var duration: String?
+            var rest: String?
+            var notes: String?
+        }
+
+        struct DayRow: Sendable {
+            var id: UUID
+            var date: Date
+            var dayTypeKey: String?
+            var dayTypeName: String?
+            var dayTypeColor: String?
+            var exerciseRefs: [(UUID, Int)]
+            var dailyNotes: String?
+        }
+
+        struct ContextRow: Sendable {
+            var date: Date
+            var note: String?
+            var tags: [PlanCSVTag]
+        }
+
+        struct LogRow: Sendable {
+            var id: UUID
+            var date: Date
+            var dayID: UUID?
+            var planExerciseID: UUID?
+            var name: String
+            var reps: Double?
+            var sets: Double?
+            var duration: Double?
+            var weight: Double?
+            var grade: String?
+            var notes: String?
+        }
+
+        struct ClimbRow: Sendable {
+            var id: UUID
+            var date: Date
+            var dayID: UUID?
+            var type: ClimbType
+            var grade: String
+            var feelsLikeGrade: String?
+            var angle: Int?
+            var holdColor: HoldColor?
+            var ropeType: RopeClimbType?
+            var style: String
+            var attempts: String?
+            var isWIP: Bool
+            var isPreviouslyClimbed: Bool
+            var gym: String
+            var notes: String?
+            var tb2UUID: String?
+        }
+
+        var plan: PlanRow
+        var exercises: [ExerciseRow]
+        var days: [DayRow]
+        var contexts: [ContextRow]
+        var logs: [LogRow]
+        var climbs: [ClimbRow]
+        var warnings: [String]
+    }
+
+    struct PlanCSVTag: Codable, Equatable, Sendable {
+        let name: String
+        let colorKey: String
+    }
+
+    private static let headers = [
+        "row_type", "plan_id", "plan_name", "start_date", "kind_key", "kind_name",
+        "kind_total_weeks", "kind_repeating", "plan_exercise_id", "catalog_exercise_id", "exercise_name",
+        "area", "exercise_description", "reps", "sets", "duration", "rest", "exercise_notes", "day_id",
+        "day_date", "day_type_key", "day_type_name", "day_type_color", "exercise_refs", "day_note",
+        "context_note", "day_tags", "session_item_id", "log_date", "log_day_id", "log_plan_exercise_id",
+        "log_exercise_name", "log_reps", "log_sets", "log_duration", "log_weight", "log_grade", "log_notes",
+        "climb_id", "climb_date", "climb_day_id", "climb_type", "climb_grade", "climb_feels_like_grade",
+        "climb_angle", "climb_hold_color", "climb_rope_type", "climb_style", "climb_attempts", "climb_wip",
+        "climb_previously_climbed", "climb_gym", "climb_notes", "tb2_uuid"
+    ]
+
+    static func export(plan: Plan, in context: ModelContext) -> PlanCSVDocument {
+        let allExercises = catalogExercises(in: context)
+        var definitions: [UUID: ParsedExchange.ExerciseRow] = [:]
+
+        for definition in plan.exerciseDefinitions {
+            definitions[definition.id] = ParsedExchange.ExerciseRow(
+                id: definition.id,
+                catalogID: definition.catalogExerciseID,
+                name: definition.name,
+                area: definition.area,
+                description: definition.exerciseDescription,
+                reps: definition.repsText,
+                sets: definition.setsText,
+                duration: definition.durationText,
+                rest: definition.restText,
+                notes: definition.notes
+            )
+        }
+
+        for day in plan.days {
+            for (index, name) in day.chosenExercises.enumerated() {
+                let existingID = day.planExerciseIDs[safe: index]
+                let catalog = allExercises.first { $0.id == day.chosenExerciseIDs[safe: index] }
+                    ?? allExercises.first { normalized($0.name) == normalized(name) }
+                let id = existingID ?? catalog?.id ?? stableID("plan-exercise|\(plan.id.uuidString)|\(name)")
+                if definitions[id] == nil {
+                    definitions[id] = ParsedExchange.ExerciseRow(
+                        id: id,
+                        catalogID: catalog?.id,
+                        name: name,
+                        area: catalog?.area,
+                        description: catalog?.exerciseDescription,
+                        reps: catalog?.repsText,
+                        sets: catalog?.setsText,
+                        duration: catalog?.durationText,
+                        rest: catalog?.restText,
+                        notes: catalog?.notes
+                    )
+                }
+            }
+        }
+
+        var rows = [headers.joined(separator: ",")]
+
+        rows.append(row(type: "plan", values: [
+            "plan_id": plan.id.uuidString,
+            "plan_name": plan.name,
+            "start_date": encodeDate(plan.startDate),
+            "kind_key": plan.kind?.key ?? "",
+            "kind_name": plan.kind?.name ?? "",
+            "kind_total_weeks": plan.kind?.totalWeeks.map(String.init) ?? "",
+            "kind_repeating": plan.kind?.isRepeating == true ? "true" : "false"
+        ]))
+
+        for definition in definitions.values.sorted(by: { $0.name.localizedStandardCompare($1.name) == .orderedAscending }) {
+            rows.append(row(type: "exercise", values: [
+                "plan_exercise_id": definition.id.uuidString,
+                "catalog_exercise_id": definition.catalogID?.uuidString ?? "",
+                "exercise_name": definition.name,
+                "area": definition.area ?? "",
+                "exercise_description": definition.description ?? "",
+                "reps": definition.reps ?? "",
+                "sets": definition.sets ?? "",
+                "duration": definition.duration ?? "",
+                "rest": definition.rest ?? "",
+                "exercise_notes": definition.notes ?? ""
+            ]))
+        }
+
+        let calendar = Calendar.current
+        for day in plan.days.sorted(by: { $0.date < $1.date }) {
+            var refs: [(UUID, Int)] = []
+            for (index, name) in day.chosenExercises.enumerated() {
+                let catalog = allExercises.first { $0.id == day.chosenExerciseIDs[safe: index] }
+                    ?? allExercises.first { normalized($0.name) == normalized(name) }
+                let id = day.planExerciseIDs[safe: index] ?? catalog?.id ?? stableID("plan-exercise|\(plan.id.uuidString)|\(name)")
+                refs.append((id, day.exerciseOrder[name] ?? index))
+            }
+            let encodedRefs = refs.map { "\($0.0.uuidString):\($0.1)" }.joined(separator: ";")
+            rows.append(row(type: "day", values: [
+                "day_id": day.id.uuidString,
+                "day_date": encodeDate(day.date),
+                "day_type_key": day.type?.key ?? "",
+                "day_type_name": day.type?.name ?? "",
+                "day_type_color": day.type?.colorKey ?? "gray",
+                "exercise_refs": encodedRefs,
+                "day_note": day.dailyNotes ?? ""
+            ]))
+
+            if let dayLog = DayLogStore.fetchDayLog(for: day.date, in: context), DayLogStore.hasContext(dayLog) {
+                let tags = DayLogStore.activeTags(from: dayLog).map { PlanCSVTag(name: $0.name, colorKey: $0.colorKey) }
+                rows.append(row(type: "context", values: [
+                    "day_date": encodeDate(calendar.startOfDay(for: day.date)),
+                    "context_note": dayLog.note ?? "",
+                    "day_tags": encodeTags(tags)
+                ]))
+            }
+        }
+
+        let sessions = (try? context.fetch(FetchDescriptor<Session>())) ?? []
+        for session in sessions.sorted(by: { $0.date < $1.date }) {
+            for item in session.items where item.planSourceId == plan.id {
+                rows.append(row(type: "exercise_log", values: [
+                    "session_item_id": item.id.uuidString,
+                    "log_date": encodeDate(session.date),
+                    "log_day_id": item.planDayId?.uuidString ?? "",
+                    "log_plan_exercise_id": item.planExerciseID?.uuidString ?? "",
+                    "log_exercise_name": item.exerciseName,
+                    "log_reps": item.reps.map(csvNumber) ?? "",
+                    "log_sets": item.sets.map(csvNumber) ?? "",
+                    "log_duration": item.duration.map(csvNumber) ?? "",
+                    "log_weight": item.weightKg.map(csvNumber) ?? "",
+                    "log_grade": item.grade ?? "",
+                    "log_notes": item.notes ?? ""
+                ]))
+            }
+        }
+
+        let climbs = (try? context.fetch(FetchDescriptor<ClimbEntry>())) ?? []
+        let linkedClimbIDs = Set(sessions.flatMap(\.items).filter { $0.planSourceId == plan.id }.compactMap(\.climbEntryId))
+        for climb in climbs where climb.planSourceId == plan.id || linkedClimbIDs.contains(climb.id) {
+            rows.append(row(type: "climb", values: [
+                "climb_id": climb.id.uuidString,
+                "climb_date": encodeDate(climb.dateLogged),
+                "climb_day_id": climb.planDayId?.uuidString ?? "",
+                "climb_type": climb.climbType.rawValue,
+                "climb_grade": climb.grade,
+                "climb_feels_like_grade": climb.feelsLikeGrade ?? "",
+                "climb_angle": climb.angleDegrees.map(String.init) ?? "",
+                "climb_hold_color": climb.holdColor?.rawValue ?? "",
+                "climb_rope_type": climb.ropeClimbType?.rawValue ?? "",
+                "climb_style": climb.style,
+                "climb_attempts": climb.attempts ?? "",
+                "climb_wip": climb.isWorkInProgress ? "true" : "false",
+                "climb_previously_climbed": climb.isPreviouslyClimbed == true ? "true" : "false",
+                "climb_gym": climb.gym,
+                "climb_notes": climb.notes ?? "",
+                "tb2_uuid": climb.tb2ClimbUUID ?? ""
+            ]))
+        }
+
+        return PlanCSVDocument(csv: rows.joined(separator: "\n"))
+    }
+
+    static func parse(_ csv: String) throws -> ParsedExchange {
+        let records = PlanCSVCodec.records(csv)
+        guard let headerRecord = records.first else { throw Error.emptyFile }
+        let header = PlanCSVCodec.line(headerRecord).map(normalizedHeader)
+        guard header.contains("row_type") else { throw Error.invalidHeader }
+
+        var rows: [[String: String]] = []
+        for record in records.dropFirst() {
+            let values = PlanCSVCodec.line(record)
+            var row: [String: String] = [:]
+            for (index, key) in header.enumerated() where index < values.count {
+                row[key] = values[index]
+            }
+            rows.append(row)
+        }
+
+        guard let planRaw = rows.first(where: { $0["row_type"] == "plan" }),
+              let planID = UUID(uuidString: planRaw["plan_id"] ?? ""),
+              let planName = nonEmpty(planRaw["plan_name"]),
+              let startDate = parseDate(planRaw["start_date"] ?? "") else {
+            throw Error.missingPlanRow
+        }
+
+        var warnings: [String] = []
+        let plan = ParsedExchange.PlanRow(
+            id: planID,
+            name: planName,
+            startDate: startDate,
+            kindKey: nonEmpty(planRaw["kind_key"]),
+            kindName: nonEmpty(planRaw["kind_name"]),
+            totalWeeks: Int(planRaw["kind_total_weeks"] ?? ""),
+            isRepeating: (planRaw["kind_repeating"] ?? "").lowercased() == "true"
+        )
+
+        var exercises: [ParsedExchange.ExerciseRow] = []
+        var days: [ParsedExchange.DayRow] = []
+        var contexts: [ParsedExchange.ContextRow] = []
+        var logs: [ParsedExchange.LogRow] = []
+        var climbs: [ParsedExchange.ClimbRow] = []
+
+        for row in rows where row["row_type"] != "plan" {
+            switch row["row_type"] {
+            case "exercise":
+                guard let id = UUID(uuidString: row["plan_exercise_id"] ?? ""), let name = nonEmpty(row["exercise_name"]) else {
+                    warnings.append("Skipped exercise row without an ID or name.")
+                    continue
+                }
+                exercises.append(.init(
+                    id: id,
+                    catalogID: UUID(uuidString: row["catalog_exercise_id"] ?? ""),
+                    name: name,
+                    area: nonEmpty(row["area"]),
+                    description: nonEmpty(row["exercise_description"]),
+                    reps: nonEmpty(row["reps"]),
+                    sets: nonEmpty(row["sets"]),
+                    duration: nonEmpty(row["duration"]),
+                    rest: nonEmpty(row["rest"]),
+                    notes: nonEmpty(row["exercise_notes"])
+                ))
+            case "day":
+                guard let id = UUID(uuidString: row["day_id"] ?? ""), let date = parseDate(row["day_date"] ?? "") else {
+                    warnings.append("Skipped day row without an ID or date.")
+                    continue
+                }
+                days.append(.init(
+                    id: id,
+                    date: date,
+                    dayTypeKey: nonEmpty(row["day_type_key"]),
+                    dayTypeName: nonEmpty(row["day_type_name"]),
+                    dayTypeColor: nonEmpty(row["day_type_color"]),
+                    exerciseRefs: parseExerciseRefs(row["exercise_refs"] ?? ""),
+                    dailyNotes: nonEmpty(row["day_note"])
+                ))
+            case "context":
+                guard let date = parseDate(row["day_date"] ?? "") else {
+                    warnings.append("Skipped context row without a date.")
+                    continue
+                }
+                contexts.append(.init(date: date, note: nonEmpty(row["context_note"]), tags: decodeTags(row["day_tags"] ?? "")))
+            case "exercise_log":
+                guard let id = UUID(uuidString: row["session_item_id"] ?? ""), let date = parseDate(row["log_date"] ?? ""), let name = nonEmpty(row["log_exercise_name"]) else {
+                    warnings.append("Skipped exercise log row without an ID, date, or name.")
+                    continue
+                }
+                logs.append(.init(
+                    id: id,
+                    date: date,
+                    dayID: UUID(uuidString: row["log_day_id"] ?? ""),
+                    planExerciseID: UUID(uuidString: row["log_plan_exercise_id"] ?? ""),
+                    name: name,
+                    reps: Double(row["log_reps"] ?? ""),
+                    sets: Double(row["log_sets"] ?? ""),
+                    duration: Double(row["log_duration"] ?? ""),
+                    weight: Double(row["log_weight"] ?? ""),
+                    grade: nonEmpty(row["log_grade"]),
+                    notes: nonEmpty(row["log_notes"])
+                ))
+            case "climb":
+                guard let id = UUID(uuidString: row["climb_id"] ?? ""), let date = parseDate(row["climb_date"] ?? ""), let grade = nonEmpty(row["climb_grade"]) else {
+                    warnings.append("Skipped climb row without an ID, date, or grade.")
+                    continue
+                }
+                climbs.append(.init(
+                    id: id,
+                    date: date,
+                    dayID: UUID(uuidString: row["climb_day_id"] ?? ""),
+                    type: ClimbType(rawValue: row["climb_type"] ?? "") ?? .boulder,
+                    grade: grade,
+                    feelsLikeGrade: nonEmpty(row["climb_feels_like_grade"]),
+                    angle: Int(row["climb_angle"] ?? ""),
+                    holdColor: HoldColor(rawValue: row["climb_hold_color"] ?? ""),
+                    ropeType: RopeClimbType(rawValue: row["climb_rope_type"] ?? ""),
+                    style: nonEmpty(row["climb_style"]) ?? "Unknown",
+                    attempts: nonEmpty(row["climb_attempts"]),
+                    isWIP: (row["climb_wip"] ?? "").lowercased() == "true",
+                    isPreviouslyClimbed: (row["climb_previously_climbed"] ?? "").lowercased() == "true",
+                    gym: nonEmpty(row["climb_gym"]) ?? "Unknown",
+                    notes: nonEmpty(row["climb_notes"]),
+                    tb2UUID: nonEmpty(row["tb2_uuid"])
+                ))
+            default:
+                warnings.append("Ignored unknown row type '\(row["row_type"] ?? "")'.")
+            }
+        }
+
+        return ParsedExchange(plan: plan, exercises: exercises, days: days, contexts: contexts, logs: logs, climbs: climbs, warnings: warnings)
+    }
+
+    static func apply(_ exchange: ParsedExchange, mode: ImportMode, in context: ModelContext) throws -> Summary {
+        let targetPlan: Plan
+        let isNew: Bool
+        switch mode {
+        case .newPlan:
+            isNew = true
+            let existingIDs = Set(((try? context.fetch(FetchDescriptor<Plan>())) ?? []).map(\.id))
+            let id = existingIDs.contains(exchange.plan.id) ? UUID() : exchange.plan.id
+            let kind = resolvePlanKind(exchange.plan, in: context)
+            targetPlan = Plan(id: id, name: exchange.plan.name, kind: kind, startDate: exchange.plan.startDate)
+            context.insert(targetPlan)
+        case .existing(let plan):
+            isNew = false
+            targetPlan = plan
+        }
+
+        if isNew == false {
+            targetPlan.name = exchange.plan.name
+            targetPlan.startDate = exchange.plan.startDate
+            if targetPlan.kind == nil { targetPlan.kind = resolvePlanKind(exchange.plan, in: context) }
+        }
+
+        let persistedExercises = (try? context.fetch(FetchDescriptor<Exercise>())) ?? []
+        let existingDefinitionIDs = Set(((try? context.fetch(FetchDescriptor<PlanExerciseDefinition>())) ?? []).map(\.id))
+        var definitionsBySourceID: [UUID: PlanExerciseDefinition] = [:]
+        var definitionsByName: [String: PlanExerciseDefinition] = [:]
+
+        for row in exchange.exercises {
+            let matched = row.catalogID.flatMap { catalogID in persistedExercises.first(where: { $0.id == catalogID }) }
+                ?? persistedExercises.first { normalized($0.name) == normalized(row.name) }
+            let catalogExercise = matched ?? createImportedExercise(from: row, in: context)
+            let existingDefinition = targetPlan.exerciseDefinitions.first { $0.id == row.id }
+                ?? targetPlan.exerciseDefinitions.first { normalized($0.name) == normalized(row.name) }
+            let definition = existingDefinition ?? PlanExerciseDefinition(
+                id: existingDefinitionIDs.contains(row.id) ? UUID() : row.id,
+                catalogExerciseID: catalogExercise.id,
+                name: row.name
+            )
+            definition.catalogExerciseID = catalogExercise.id
+            definition.name = row.name
+            definition.area = row.area
+            definition.exerciseDescription = row.description
+            definition.repsText = row.reps
+            definition.setsText = row.sets
+            definition.durationText = row.duration
+            definition.restText = row.rest
+            definition.notes = row.notes
+            if definition.modelContext == nil {
+                targetPlan.exerciseDefinitions.append(definition)
+                context.insert(definition)
+            }
+            definitionsBySourceID[row.id] = definition
+            definitionsByName[normalized(row.name)] = definition
+        }
+
+        let calendar = Calendar.current
+        let existingDayIDs = Set(((try? context.fetch(FetchDescriptor<PlanDay>())) ?? []).map(\.id))
+        var existingDaysByDate: [Date: PlanDay] = [:]
+        for day in targetPlan.days {
+            existingDaysByDate[calendar.startOfDay(for: day.date)] = day
+        }
+        let currentSessions = (try? context.fetch(FetchDescriptor<Session>())) ?? []
+        let currentItems = currentSessions.flatMap(\.items).filter { $0.planSourceId == targetPlan.id }
+        let currentClimbs = ((try? context.fetch(FetchDescriptor<ClimbEntry>())) ?? []).filter { $0.planSourceId == targetPlan.id }
+        let importedDates = Set(exchange.days.map { calendar.startOfDay(for: $0.date) })
+
+        for dayRow in exchange.days {
+            let dayDate = calendar.startOfDay(for: dayRow.date)
+            let day = existingDaysByDate[dayDate] ?? {
+                let created = PlanDay(id: existingDayIDs.contains(dayRow.id) ? UUID() : dayRow.id, date: dayDate)
+                targetPlan.days.append(created)
+                return created
+            }()
+            let dayItems = currentItems.filter { item in
+                if let planDayId = item.planDayId { return planDayId == day.id }
+                return sessionsDate(for: item, in: currentSessions, calendar: calendar) == dayDate
+            }
+            let dayClimbs = currentClimbs.filter { calendar.startOfDay(for: $0.dateLogged) == dayDate }
+            let hasProtectedRecords = !dayItems.isEmpty || !dayClimbs.isEmpty
+
+            if !hasProtectedRecords || isNew {
+                day.type = resolveDayType(key: dayRow.dayTypeKey, name: dayRow.dayTypeName, color: dayRow.dayTypeColor, in: context)
+                day.dailyNotes = dayRow.dailyNotes
+            }
+
+            let incomingDefinitions = dayRow.exerciseRefs.compactMap { sourceID, order in
+                if let definition = definitionsBySourceID[sourceID] {
+                    return (definition, order)
+                }
+                return nil
+            }
+            if !hasProtectedRecords || isNew {
+                day.planExerciseIDs = incomingDefinitions.map { $0.0.id }
+                day.chosenExercises = incomingDefinitions.map { $0.0.name }
+                day.exerciseOrder = Dictionary(uniqueKeysWithValues: incomingDefinitions.map { ($0.0.name, $0.1) })
+                day.chosenExerciseIDs = incomingDefinitions.compactMap { $0.0.catalogExerciseID }
+                day.exerciseOrderByID = Dictionary(uniqueKeysWithValues: incomingDefinitions.compactMap { definition, order in
+                    guard let catalogID = definition.catalogExerciseID else { return nil }
+                    return (catalogID.uuidString, order)
+                })
+            } else {
+                var names = incomingDefinitions.map { $0.0.name }
+                var planIDs = incomingDefinitions.map { $0.0.id }
+                for item in dayItems where !names.contains(item.exerciseName) {
+                    names.append(item.exerciseName)
+                    if let id = item.planExerciseID {
+                        planIDs.append(id)
+                    } else if let definition = definitionsByName[normalized(item.exerciseName)] {
+                        planIDs.append(definition.id)
+                    }
+                }
+                day.chosenExercises = names
+                day.planExerciseIDs = planIDs
+            }
+        }
+
+        if !isNew {
+            targetPlan.days.removeAll { day in
+                let date = calendar.startOfDay(for: day.date)
+                guard !importedDates.contains(date) else { return false }
+                let hasItems = currentItems.contains { item in
+                    if let planDayId = item.planDayId { return planDayId == day.id }
+                    return sessionsDate(for: item, in: currentSessions, calendar: calendar) == date
+                }
+                let hasClimbs = currentClimbs.contains { calendar.startOfDay(for: $0.dateLogged) == date }
+                return !hasItems && !hasClimbs && !DayLogStore.hasContext(DayLogStore.fetchDayLog(for: date, in: context))
+            }
+        }
+
+        applyContexts(exchange.contexts, in: context)
+        let insertedLogs = importLogs(exchange.logs, into: targetPlan, definitions: definitionsBySourceID, isNew: isNew, in: context, calendar: calendar)
+        let insertedClimbs = importClimbs(exchange.climbs, into: targetPlan, isNew: isNew, in: context, calendar: calendar)
+        try context.save()
+
+        return Summary(
+            planName: targetPlan.name,
+            dayCount: exchange.days.count,
+            exerciseCount: exchange.exercises.count,
+            logCount: insertedLogs,
+            climbCount: insertedClimbs,
+            warnings: exchange.warnings
+        )
+    }
+
+    enum Error: Swift.Error, LocalizedError {
+        case emptyFile
+        case invalidHeader
+        case missingPlanRow
+
+        var errorDescription: String? {
+            switch self {
+            case .emptyFile: return "The plan CSV is empty."
+            case .invalidHeader: return "This is not a supported plan CSV file."
+            case .missingPlanRow: return "The plan CSV does not contain a valid plan row."
+            }
+        }
+    }
+
+    private static func importLogs(_ rows: [ParsedExchange.LogRow], into plan: Plan, definitions: [UUID: PlanExerciseDefinition], isNew: Bool, in context: ModelContext, calendar: Calendar) -> Int {
+        var sessions = (try? context.fetch(FetchDescriptor<Session>())) ?? []
+        let existingItems = (try? context.fetch(FetchDescriptor<SessionItem>())) ?? []
+        var existingItemIDs = Set(existingItems.map(\.id))
+        var inserted = 0
+        for row in rows {
+            let itemID: UUID
+            if existingItemIDs.contains(row.id) {
+                guard isNew else { continue }
+                itemID = UUID()
+            } else {
+                itemID = row.id
+            }
+            let start = calendar.startOfDay(for: row.date)
+            let session = sessions.first { calendar.startOfDay(for: $0.date) == start } ?? {
+                let created = Session(id: UUID(), date: start)
+                context.insert(created)
+                sessions.append(created)
+                return created
+            }()
+            let targetDayID = plan.days.first(where: { calendar.isDate($0.date, inSameDayAs: row.date) })?.id
+            let item = SessionItem(id: itemID, exerciseName: row.name, planSourceId: plan.id, planName: plan.name, planDayId: targetDayID, planExerciseID: row.planExerciseID.flatMap { definitions[$0]?.id } ?? definitions.values.first(where: { normalized($0.name) == normalized(row.name) })?.id, reps: row.reps, sets: row.sets, weightKg: row.weight, grade: row.grade, notes: row.notes, duration: row.duration)
+            session.items.append(item)
+            existingItemIDs.insert(itemID)
+            inserted += 1
+        }
+        return inserted
+    }
+
+    private static func importClimbs(_ rows: [ParsedExchange.ClimbRow], into plan: Plan, isNew: Bool, in context: ModelContext, calendar: Calendar) -> Int {
+        let existing = (try? context.fetch(FetchDescriptor<ClimbEntry>())) ?? []
+        var existingIDs = Set(existing.map(\.id))
+        var inserted = 0
+        for row in rows {
+            let climbID: UUID
+            if existingIDs.contains(row.id) {
+                guard isNew else { continue }
+                climbID = UUID()
+            } else {
+                climbID = row.id
+            }
+            let targetDayID = plan.days.first(where: { calendar.isDate($0.date, inSameDayAs: row.date) })?.id
+            context.insert(ClimbEntry(id: climbID, climbType: row.type, ropeClimbType: row.ropeType, grade: row.grade, feelsLikeGrade: row.feelsLikeGrade, angleDegrees: row.angle, style: row.style, attempts: row.attempts, isWorkInProgress: row.isWIP, isPreviouslyClimbed: row.isPreviouslyClimbed, holdColor: row.holdColor, gym: row.gym, notes: row.notes, dateLogged: row.date, planSourceId: plan.id, planDayId: targetDayID, tb2ClimbUUID: row.tb2UUID))
+            existingIDs.insert(climbID)
+            inserted += 1
+        }
+        return inserted
+    }
+
+    private static func applyContexts(_ rows: [ParsedExchange.ContextRow], in context: ModelContext) {
+        for row in rows {
+            let existing = DayLogStore.fetchDayLog(for: row.date, in: context)
+            if let existing, DayLogStore.hasContext(existing) { continue }
+            let dayLog = existing ?? DayLogStore.dayLog(for: row.date, in: context)
+            guard let dayLog else { continue }
+            DayLogStore.setNote(row.note ?? "", for: dayLog)
+            dayLog.tags = row.tags.compactMap { tag in
+                DayLogStore.createTag(name: tag.name, colorKey: tag.colorKey, in: context)
+            }
+        }
+    }
+
+    private static func resolvePlanKind(_ row: ParsedExchange.PlanRow, in context: ModelContext) -> PlanKindModel? {
+        guard let key = row.kindKey, !key.isEmpty else { return nil }
+        if let existing = ((try? context.fetch(FetchDescriptor<PlanKindModel>())) ?? []).first(where: { $0.key == key }) { return existing }
+        let kind = PlanKindModel(key: key, name: row.kindName ?? key.capitalized, totalWeeks: row.totalWeeks, isRepeating: row.isRepeating)
+        context.insert(kind)
+        return kind
+    }
+
+    private static func resolveDayType(key: String?, name: String?, color: String?, in context: ModelContext) -> DayTypeModel? {
+        let types = (try? context.fetch(FetchDescriptor<DayTypeModel>())) ?? []
+        if let key, let found = types.first(where: { $0.key == key }) { return found }
+        if let name, let found = types.first(where: { $0.name == name }) { return found }
+        guard let key = nonEmpty(key), let name = nonEmpty(name) else { return nil }
+        let type = DayTypeModel(key: key, name: name, colorKey: color ?? "gray")
+        context.insert(type)
+        return type
+    }
+
+    private static func createImportedExercise(from row: ParsedExchange.ExerciseRow, in context: ModelContext) -> Exercise {
+        let activities = (try? context.fetch(FetchDescriptor<Activity>())) ?? []
+        let activity = activities.first(where: { normalized($0.name) == normalized("Imported") }) ?? {
+            let created = Activity(name: "Imported")
+            context.insert(created)
+            return created
+        }()
+        let type = activity.types.first(where: { normalized($0.name) == normalized("Imported Plans") }) ?? {
+            let created = TrainingType(name: "Imported Plans")
+            activity.types.append(created)
+            return created
+        }()
+        if let existing = type.exercises.first(where: { normalized($0.name) == normalized(row.name) }) { return existing }
+        let existingExercises = (try? context.fetch(FetchDescriptor<Exercise>())) ?? []
+        let importedID = if let catalogID = row.catalogID, !existingExercises.contains(where: { $0.id == catalogID }) {
+            catalogID
+        } else {
+            UUID()
+        }
+        let exercise = Exercise(id: importedID, name: row.name, area: row.area, exerciseDescription: row.description, repsText: row.reps, durationText: row.duration, setsText: row.sets, restText: row.rest, notes: row.notes)
+        type.exercises.append(exercise)
+        context.insert(exercise)
+        return exercise
+    }
+
+    private static func catalogExercises(in context: ModelContext) -> [Exercise] {
+        let activities = (try? context.fetch(FetchDescriptor<Activity>())) ?? []
+        var result: [Exercise] = []
+        var seen: Set<UUID> = []
+        for activity in activities {
+            for type in activity.types {
+                for exercise in type.exercises where seen.insert(exercise.id).inserted { result.append(exercise) }
+                for combination in type.combinations {
+                    for exercise in combination.exercises where seen.insert(exercise.id).inserted { result.append(exercise) }
+                }
+            }
+        }
+        return result
+    }
+
+    private static func sessionsDate(for item: SessionItem, in sessions: [Session], calendar: Calendar) -> Date? {
+        sessions.first(where: { $0.items.contains(where: { $0.id == item.id }) }).map { calendar.startOfDay(for: $0.date) }
+    }
+
+    private static func row(type: String, values: [String: String]) -> String {
+        var all = Array(repeating: "", count: headers.count)
+        if let index = headers.firstIndex(of: "row_type") { all[index] = type }
+        for (key, value) in values {
+            if let index = headers.firstIndex(of: key) { all[index] = PlanCSVCodec.escape(value) }
+        }
+        return all.joined(separator: ",")
+    }
+
+    private static func normalizedHeader(_ value: String) -> String { value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+
+    private static func normalized(_ value: String) -> String { value.trimmingCharacters(in: .whitespacesAndNewlines).folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current) }
+    private static func nonEmpty(_ value: String?) -> String? { guard let value else { return nil }; let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines); return trimmed.isEmpty ? nil : trimmed }
+    private static func encodeDate(_ date: Date) -> String { ISO8601DateFormatter.planExchange.string(from: date) }
+    private static func parseDate(_ raw: String) -> Date? { ISO8601DateFormatter.planExchange.date(from: raw) ?? DateFormatter.planExchange.date(from: raw) }
+    private static func encodeTags(_ tags: [PlanCSVTag]) -> String { guard let data = try? JSONEncoder().encode(tags) else { return "[]" }; return String(decoding: data, as: UTF8.self) }
+    private static func decodeTags(_ raw: String) -> [PlanCSVTag] { guard let data = raw.data(using: .utf8), let tags = try? JSONDecoder().decode([PlanCSVTag].self, from: data) else { return [] }; return tags }
+    private static func parseExerciseRefs(_ raw: String) -> [(UUID, Int)] { raw.split(separator: ";").compactMap { part in let values = part.split(separator: ":"); guard values.count >= 1, let id = UUID(uuidString: String(values[0])) else { return nil }; return (id, Int(values[safe: 1].map(String.init) ?? "") ?? 0) } }
+    private static func csvNumber(_ value: Double) -> String { value.formatted(.number.locale(Locale(identifier: "en_US_POSIX")).precision(.fractionLength(3))) }
+    private static func stableID(_ value: String) -> UUID {
+        let bytes = Array(SHA256.hash(data: Data(value.utf8)).prefix(16))
+        let tuple: uuid_t = (
+            bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
+            bytes[8], bytes[9], bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15]
+        )
+        return UUID(uuid: tuple)
+    }
+}
+
+private enum PlanCSVCodec {
+    static func escape(_ value: String) -> String {
+        guard value.contains(",") || value.contains("\"") || value.contains("\n") || value.contains("\r") else { return value }
+        return "\"\(value.replacingOccurrences(of: "\"", with: "\"\""))\""
+    }
+
+    static func line(_ record: String) -> [String] {
+        var result: [String] = []
+        var value = ""
+        var quoted = false
+        let chars = Array(record)
+        var index = 0
+        while index < chars.count {
+            let character = chars[index]
+            if character == "\"" {
+                if quoted, index + 1 < chars.count, chars[index + 1] == "\"" { value.append("\""); index += 1 } else { quoted.toggle() }
+            } else if character == "," && !quoted { result.append(value); value = "" } else { value.append(character) }
+            index += 1
+        }
+        result.append(value)
+        return result
+    }
+
+    static func records(_ csv: String) -> [String] {
+        var result: [String] = []
+        var current = ""
+        var quoted = false
+        let chars = Array(csv)
+        var index = 0
+        while index < chars.count {
+            let character = chars[index]
+            if character == "\"" {
+                current.append(character)
+                if quoted, index + 1 < chars.count, chars[index + 1] == "\"" { current.append(chars[index + 1]); index += 1 } else { quoted.toggle() }
+            } else if (character == "\n" || character == "\r") && !quoted {
+                if !current.isEmpty { result.append(current); current = "" }
+                if character == "\r", index + 1 < chars.count, chars[index + 1] == "\n" { index += 1 }
+            } else { current.append(character) }
+            index += 1
+        }
+        if !current.isEmpty { result.append(current) }
+        return result
+    }
+}
+
+private extension Array {
+    subscript(safe index: Int) -> Element? { indices.contains(index) ? self[index] : nil }
+}
+
+private extension ISO8601DateFormatter {
+    static var planExchange: ISO8601DateFormatter {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }
+}
+
+private extension DateFormatter {
+    static var planExchange: DateFormatter {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = .current
+        return formatter
+    }
+}

--- a/ClimbingProgram/data/io/PlanCSVExchange.swift
+++ b/ClimbingProgram/data/io/PlanCSVExchange.swift
@@ -448,7 +448,12 @@ enum PlanCSVExchange {
         return ParsedExchange(plan: plan, exercises: exercises, days: days, contexts: contexts, logs: logs, climbs: climbs, warnings: warnings)
     }
 
-    static func apply(_ exchange: ParsedExchange, mode: ImportMode, in context: ModelContext) throws -> Summary {
+    static func apply(
+        _ exchange: ParsedExchange,
+        mode: ImportMode,
+        overwriteDayContext: Bool = false,
+        in context: ModelContext
+    ) throws -> Summary {
         let targetPlan: Plan
         let isNew: Bool
         switch mode {
@@ -467,13 +472,21 @@ enum PlanCSVExchange {
         if isNew == false {
             targetPlan.name = exchange.plan.name
             targetPlan.startDate = exchange.plan.startDate
-            if targetPlan.kind == nil { targetPlan.kind = resolvePlanKind(exchange.plan, in: context) }
+            targetPlan.kind = resolvePlanKind(exchange.plan, in: context)
         }
 
         let persistedExercises = (try? context.fetch(FetchDescriptor<Exercise>())) ?? []
         let existingDefinitionIDs = Set(((try? context.fetch(FetchDescriptor<PlanExerciseDefinition>())) ?? []).map(\.id))
         var definitionsBySourceID: [UUID: PlanExerciseDefinition] = [:]
         var definitionsByName: [String: PlanExerciseDefinition] = [:]
+        var definitionsByID: [UUID: PlanExerciseDefinition] = [:]
+
+        // Keep existing definitions available when a CSV removes an exercise
+        // that still has a protected logged record on one of the plan days.
+        for definition in targetPlan.exerciseDefinitions {
+            definitionsByName[normalized(definition.name)] = definition
+            definitionsByID[definition.id] = definition
+        }
 
         for row in exchange.exercises {
             let matched = row.catalogID.flatMap { catalogID in persistedExercises.first(where: { $0.id == catalogID }) }
@@ -501,6 +514,7 @@ enum PlanCSVExchange {
             }
             definitionsBySourceID[row.id] = definition
             definitionsByName[normalized(row.name)] = definition
+            definitionsByID[definition.id] = definition
         }
 
         let calendar = Calendar.current
@@ -525,13 +539,8 @@ enum PlanCSVExchange {
                 if let planDayId = item.planDayId { return planDayId == day.id }
                 return sessionsDate(for: item, in: currentSessions, calendar: calendar) == dayDate
             }
-            let dayClimbs = currentClimbs.filter { calendar.startOfDay(for: $0.dateLogged) == dayDate }
-            let hasProtectedRecords = !dayItems.isEmpty || !dayClimbs.isEmpty
-
-            if !hasProtectedRecords || isNew {
-                day.type = resolveDayType(key: dayRow.dayTypeKey, name: dayRow.dayTypeName, color: dayRow.dayTypeColor, in: context)
-                day.dailyNotes = dayRow.dailyNotes
-            }
+            day.type = resolveDayType(key: dayRow.dayTypeKey, name: dayRow.dayTypeName, color: dayRow.dayTypeColor, in: context)
+            day.dailyNotes = dayRow.dailyNotes
 
             let incomingDefinitions = dayRow.exerciseRefs.compactMap { sourceID, order in
                 if let definition = definitionsBySourceID[sourceID] {
@@ -539,29 +548,40 @@ enum PlanCSVExchange {
                 }
                 return nil
             }
-            if !hasProtectedRecords || isNew {
-                day.planExerciseIDs = incomingDefinitions.map { $0.0.id }
-                day.chosenExercises = incomingDefinitions.map { $0.0.name }
-                day.exerciseOrder = Dictionary(uniqueKeysWithValues: incomingDefinitions.map { ($0.0.name, $0.1) })
-                day.chosenExerciseIDs = incomingDefinitions.compactMap { $0.0.catalogExerciseID }
-                day.exerciseOrderByID = Dictionary(uniqueKeysWithValues: incomingDefinitions.compactMap { definition, order in
-                    guard let catalogID = definition.catalogExerciseID else { return nil }
-                    return (catalogID.uuidString, order)
-                })
-            } else {
-                var names = incomingDefinitions.map { $0.0.name }
-                var planIDs = incomingDefinitions.map { $0.0.id }
-                for item in dayItems where !names.contains(item.exerciseName) {
-                    names.append(item.exerciseName)
-                    if let id = item.planExerciseID {
-                        planIDs.append(id)
-                    } else if let definition = definitionsByName[normalized(item.exerciseName)] {
-                        planIDs.append(definition.id)
-                    }
+            var names = incomingDefinitions.map { $0.0.name }
+            var planIDs = incomingDefinitions.map { $0.0.id }
+            var exerciseOrder = Dictionary(uniqueKeysWithValues: incomingDefinitions.map { ($0.0.name, $0.1) })
+            var chosenExerciseIDs = incomingDefinitions.compactMap { $0.0.catalogExerciseID }
+            var exerciseOrderByID: [String: Int] = Dictionary(uniqueKeysWithValues: incomingDefinitions.compactMap { definition, order in
+                guard let catalogID = definition.catalogExerciseID else { return nil }
+                return (catalogID.uuidString, order)
+            })
+            let nextOrderStart = (incomingDefinitions.map { $0.1 }.max() ?? -1) + 1
+            var nextProtectedOrder = nextOrderStart
+
+            // A logged exercise is retained when it was removed from the CSV,
+            // but all other schedule data follows the CSV, including ordering.
+            for item in dayItems where !names.contains(where: { normalized($0) == normalized(item.exerciseName) }) {
+                names.append(item.exerciseName)
+                if let id = item.planExerciseID {
+                    planIDs.append(id)
+                } else if let definition = definitionsByName[normalized(item.exerciseName)] {
+                    planIDs.append(definition.id)
                 }
-                day.chosenExercises = names
-                day.planExerciseIDs = planIDs
+                exerciseOrder[item.exerciseName] = nextProtectedOrder
+                if let definition = item.planExerciseID.flatMap({ definitionsByID[$0] })
+                    ?? definitionsByName[normalized(item.exerciseName)],
+                   let catalogID = definition.catalogExerciseID {
+                    chosenExerciseIDs.append(catalogID)
+                    exerciseOrderByID[catalogID.uuidString] = nextProtectedOrder
+                }
+                nextProtectedOrder += 1
             }
+            day.planExerciseIDs = planIDs
+            day.chosenExercises = names
+            day.exerciseOrder = exerciseOrder
+            day.chosenExerciseIDs = chosenExerciseIDs
+            day.exerciseOrderByID = exerciseOrderByID
         }
 
         if !isNew {
@@ -573,11 +593,13 @@ enum PlanCSVExchange {
                     return sessionsDate(for: item, in: currentSessions, calendar: calendar) == date
                 }
                 let hasClimbs = currentClimbs.contains { calendar.startOfDay(for: $0.dateLogged) == date }
-                return !hasItems && !hasClimbs && !DayLogStore.hasContext(DayLogStore.fetchDayLog(for: date, in: context))
+                return !hasItems && !hasClimbs
             }
         }
 
-        applyContexts(exchange.contexts, in: context)
+        if overwriteDayContext {
+            applyContexts(exchange.contexts, in: context)
+        }
         let insertedLogs = importLogs(exchange.logs, into: targetPlan, definitions: definitionsBySourceID, isNew: isNew, in: context, calendar: calendar)
         let insertedClimbs = importClimbs(exchange.climbs, into: targetPlan, isNew: isNew, in: context, calendar: calendar)
         try context.save()

--- a/ClimbingProgram/data/io/PlanCSVExchange.swift
+++ b/ClimbingProgram/data/io/PlanCSVExchange.swift
@@ -331,13 +331,19 @@ enum PlanCSVExchange {
         }
 
         guard let planRaw = rows.first(where: { $0["row_type"] == "plan" }),
-              let planID = UUID(uuidString: planRaw["plan_id"] ?? ""),
               let planName = nonEmpty(planRaw["plan_name"]),
               let startDate = parseDate(planRaw["start_date"] ?? "") else {
             throw Error.missingPlanRow
         }
 
         var warnings: [String] = []
+        let planID: UUID
+        if let importedPlanID = UUID(uuidString: planRaw["plan_id"] ?? "") {
+            planID = importedPlanID
+        } else {
+            planID = UUID()
+            warnings.append("The plan row did not contain a valid plan ID; a new ID was generated.")
+        }
         let plan = ParsedExchange.PlanRow(
             id: planID,
             name: planName,

--- a/ClimbingProgram/data/io/PlanCSVExchange.swift
+++ b/ClimbingProgram/data/io/PlanCSVExchange.swift
@@ -491,7 +491,6 @@ enum PlanCSVExchange {
             planID = importedPlanID
         } else {
             planID = UUID()
-            warnings.append("The plan row did not contain a valid plan ID; a new ID was generated.")
         }
         let plan = ParsedExchange.PlanRow(
             id: planID,

--- a/ClimbingProgram/data/io/PlanCSVExchange.swift
+++ b/ClimbingProgram/data/io/PlanCSVExchange.swift
@@ -138,6 +138,26 @@ enum PlanCSVExchange {
         let colorKey: String
     }
 
+    static func exportFilename(for plan: Plan, exportedAt: Date = .now) -> String {
+        let safeName = plan.name
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .map { character in
+                character.isLetter || character.isNumber ? String(character) : "_"
+            }
+            .joined()
+            .split(separator: "_", omittingEmptySubsequences: true)
+            .joined(separator: "_")
+
+        let calendar = Calendar.current
+        let components = calendar.dateComponents([.year, .month, .day], from: exportedAt)
+        let year = components.year ?? 0
+        let month = twoDigit(components.month ?? 0)
+        let day = twoDigit(components.day ?? 0)
+        let date = "\(year)-\(month)-\(day)"
+
+        return "klettrack_\(safeName.isEmpty ? "plan" : safeName)_\(date)"
+    }
+
     private static let headers = [
         "row_type", "plan_id", "plan_name", "start_date", "kind_key", "kind_name",
         "kind_total_weeks", "kind_repeating", "plan_exercise_id", "catalog_exercise_id", "exercise_name",
@@ -716,6 +736,7 @@ enum PlanCSVExchange {
     private static func normalizedHeader(_ value: String) -> String { value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
 
     private static func normalized(_ value: String) -> String { value.trimmingCharacters(in: .whitespacesAndNewlines).folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current) }
+    private static func twoDigit(_ value: Int) -> String { value < 10 ? "0\(value)" : String(value) }
     private static func nonEmpty(_ value: String?) -> String? { guard let value else { return nil }; let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines); return trimmed.isEmpty ? nil : trimmed }
     private static func encodeDate(_ date: Date) -> String { ISO8601DateFormatter.planExchange.string(from: date) }
     private static func parseDate(_ raw: String) -> Date? { ISO8601DateFormatter.planExchange.date(from: raw) ?? DateFormatter.planExchange.date(from: raw) }

--- a/ClimbingProgram/data/models/ClimbModels.swift
+++ b/ClimbingProgram/data/models/ClimbModels.swift
@@ -27,6 +27,8 @@ final class ClimbEntry {
     var gym: String
     var notes: String?
     var dateLogged: Date
+    var planSourceId: UUID?
+    var planDayId: UUID?
     var tb2ClimbUUID: String?
     var kilterLogUuid: String?
     var kilterClimbUuid: String?
@@ -50,6 +52,8 @@ final class ClimbEntry {
         gym: String,
         notes: String? = nil,
         dateLogged: Date = Date(),
+        planSourceId: UUID? = nil,
+        planDayId: UUID? = nil,
         tb2ClimbUUID: String? = nil,
         kilterLogUuid: String? = nil,
         kilterClimbUuid: String? = nil
@@ -68,6 +72,8 @@ final class ClimbEntry {
         self.gym = gym
         self.notes = notes
         self.dateLogged = dateLogged
+        self.planSourceId = planSourceId
+        self.planDayId = planDayId
         self.tb2ClimbUUID = tb2ClimbUUID
         self.kilterLogUuid = kilterLogUuid
         self.kilterClimbUuid = kilterClimbUuid

--- a/ClimbingProgram/data/models/Models.swift
+++ b/ClimbingProgram/data/models/Models.swift
@@ -114,6 +114,9 @@ final class SessionItem {
     var sort: Int = 0
     var planSourceId: UUID?
     var planName: String?
+    var planDayId: UUID?
+    var planExerciseID: UUID?
+    var climbEntryId: UUID?
 
     // Structured metrics
     var reps: Double?
@@ -128,6 +131,9 @@ final class SessionItem {
         exerciseName: String,
         planSourceId: UUID? = nil,
         planName: String? = nil,
+        planDayId: UUID? = nil,
+        planExerciseID: UUID? = nil,
+        climbEntryId: UUID? = nil,
         reps: Double? = nil,
         sets: Double? = nil,
         weightKg: Double? = nil,
@@ -139,6 +145,9 @@ final class SessionItem {
         self.exerciseName = exerciseName
         self.planSourceId = planSourceId
         self.planName = planName
+        self.planDayId = planDayId
+        self.planExerciseID = planExerciseID
+        self.climbEntryId = climbEntryId
         self.reps = reps
         self.sets = sets
         self.weightKg = weightKg

--- a/ClimbingProgram/data/models/Plans.swift
+++ b/ClimbingProgram/data/models/Plans.swift
@@ -112,6 +112,9 @@ final class Plan {
     var startDate: Date
     @Relationship(deleteRule: .nullify) var kind: PlanKindModel?
     var days: [PlanDay] = []
+    // Plan-local exercise definitions allow imported plans to carry guidance
+    // without changing the global catalog exercise.
+    var exerciseDefinitions: [PlanExerciseDefinition] = []
 
     // Weekly recurrence templates keyed by Calendar weekday (1...7).
     // Copies only the "setup" (chosen exercises + order + day type).
@@ -127,6 +130,44 @@ final class Plan {
     }
 }
 
+@Model
+final class PlanExerciseDefinition {
+    @Attribute(.unique) var id: UUID
+    var catalogExerciseID: UUID?
+    var name: String
+    var area: String?
+    var exerciseDescription: String?
+    var repsText: String?
+    var durationText: String?
+    var setsText: String?
+    var restText: String?
+    var notes: String?
+
+    init(
+        id: UUID = UUID(),
+        catalogExerciseID: UUID? = nil,
+        name: String,
+        area: String? = nil,
+        exerciseDescription: String? = nil,
+        repsText: String? = nil,
+        durationText: String? = nil,
+        setsText: String? = nil,
+        restText: String? = nil,
+        notes: String? = nil
+    ) {
+        self.id = id
+        self.catalogExerciseID = catalogExerciseID
+        self.name = name
+        self.area = area
+        self.exerciseDescription = exerciseDescription
+        self.repsText = repsText
+        self.durationText = durationText
+        self.setsText = setsText
+        self.restText = restText
+        self.notes = notes
+    }
+}
+
 
 @Model
 final class PlanDay {
@@ -135,6 +176,7 @@ final class PlanDay {
     // Relationship to DayTypeModel (replaces enum/raw storage)
     @Relationship(deleteRule: .nullify) var type: DayTypeModel?
     var chosenExerciseIDs: [UUID] = []
+    var planExerciseIDs: [UUID] = []
     var exerciseOrderByID: [String:Int] = [:]
     var chosenExercises: [String] = []
     var exerciseOrder: [String:Int] = [:]

--- a/ClimbingProgram/data/persistence/DayLogStore.swift
+++ b/ClimbingProgram/data/persistence/DayLogStore.swift
@@ -23,7 +23,7 @@ enum DayLogStore {
 
     static func hasContext(_ dayLog: DayLog?) -> Bool {
         guard let dayLog else { return false }
-        let hasNote = dayLog.note?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+        let hasNote = dayLog.note?.isEmpty == false
         return hasNote || !activeTags(from: dayLog).isEmpty
     }
 
@@ -51,8 +51,7 @@ enum DayLogStore {
     }
 
     static func setNote(_ rawNote: String, for dayLog: DayLog) {
-        let trimmed = rawNote.trimmingCharacters(in: .whitespacesAndNewlines)
-        dayLog.note = trimmed.isEmpty ? nil : trimmed
+        dayLog.note = rawNote.isEmpty ? nil : rawNote
     }
 
     static func activeTag(named rawName: String, in context: ModelContext, excluding id: UUID? = nil) -> DayTag? {

--- a/ClimbingProgram/features/catalog/CatalogDeletion.swift
+++ b/ClimbingProgram/features/catalog/CatalogDeletion.swift
@@ -106,17 +106,30 @@ enum CatalogDeletion {
         let trainingTypes = fetchTrainingTypes(in: context)
         let combinations = fetchCombinations(in: context)
         let exercises = fetchExercises(in: context)
+        var survivingTypePlacements: [(TrainingType, Exercise)] = []
+        var survivingCombinationPlacements: [(BoulderCombination, Exercise)] = []
 
         for activity in activities {
             activity.types.removeAll { graph.typeIDs.contains($0.id) }
         }
         for trainingType in trainingTypes {
             trainingType.combinations.removeAll { graph.combinationIDs.contains($0.id) }
-            trainingType.exercises.removeAll { graph.exerciseIDs.contains($0.id) && graph.typeIDs.contains(trainingType.id) }
+            for exercise in trainingType.exercises where graph.exerciseIDs.contains(exercise.id) && !graph.typeIDs.contains(trainingType.id) {
+                survivingTypePlacements.append((trainingType, exercise))
+            }
+            trainingType.exercises.removeAll { graph.exerciseIDs.contains($0.id) }
         }
-        for combination in combinations where graph.combinationIDs.contains(combination.id) {
+        for combination in combinations {
+            for exercise in combination.exercises where graph.exerciseIDs.contains(exercise.id) && !graph.combinationIDs.contains(combination.id) {
+                survivingCombinationPlacements.append((combination, exercise))
+            }
             combination.exercises.removeAll { graph.exerciseIDs.contains($0.id) }
         }
+
+        // Persist relationship detachment before deleting catalog nodes. SwiftData can
+        // otherwise cascade-delete a shared Exercise from the node's prior relationship
+        // snapshot even when that exercise is still placed in another node.
+        try context.save()
 
         for combination in combinations where graph.combinationIDs.contains(combination.id) {
             context.delete(combination)
@@ -126,6 +139,13 @@ enum CatalogDeletion {
         }
         for activity in activities where graph.activityIDs.contains(activity.id) {
             context.delete(activity)
+        }
+
+        for (trainingType, exercise) in survivingTypePlacements where !trainingType.exercises.contains(where: { $0.id == exercise.id }) {
+            trainingType.exercises.append(exercise)
+        }
+        for (combination, exercise) in survivingCombinationPlacements where !combination.exercises.contains(where: { $0.id == exercise.id }) {
+            combination.exercises.append(exercise)
         }
 
         let remainingExerciseIDs = catalogExerciseIDs(in: context)

--- a/ClimbingProgram/features/catalog/CatalogDeletion.swift
+++ b/ClimbingProgram/features/catalog/CatalogDeletion.swift
@@ -1,0 +1,285 @@
+import Foundation
+import SwiftData
+
+enum CatalogDeletion {
+    enum Target: Identifiable {
+        case activity(Activity)
+        case trainingType(TrainingType)
+        case combination(BoulderCombination)
+
+        var id: UUID {
+            switch self {
+            case .activity(let activity): return activity.id
+            case .trainingType(let trainingType): return trainingType.id
+            case .combination(let combination): return combination.id
+            }
+        }
+
+        var name: String {
+            switch self {
+            case .activity(let activity): return activity.name
+            case .trainingType(let trainingType): return trainingType.name
+            case .combination(let combination): return combination.name
+            }
+        }
+
+        var kindName: String {
+            switch self {
+            case .activity: return "category"
+            case .trainingType: return "training type"
+            case .combination: return "combination"
+            }
+        }
+    }
+
+    struct Impact {
+        let nodeCount: Int
+        let exerciseCount: Int
+
+        var isEmpty: Bool { nodeCount == 0 && exerciseCount == 0 }
+
+        var message: String {
+            var parts: [String] = []
+            if nodeCount > 0 {
+                parts.append("\(nodeCount) nested catalog node\(nodeCount == 1 ? "" : "s")")
+            }
+            if exerciseCount > 0 {
+                parts.append("\(exerciseCount) exercise\(exerciseCount == 1 ? "" : "s")")
+            }
+            guard !parts.isEmpty else {
+                return "This empty catalog node will be deleted."
+            }
+            return "This will delete " + parts.joined(separator: " and ") + ". Plans, logs, climbs, and plan-local exercise data will be preserved."
+        }
+    }
+
+    struct Request: Identifiable {
+        let id = UUID()
+        let targets: [Target]
+        let impact: Impact
+
+        var title: String {
+            if targets.count == 1, let target = targets.first {
+                return "Delete \(target.name)?"
+            }
+            return "Delete \(targets.count) catalog nodes?"
+        }
+
+        var message: String { impact.message }
+    }
+
+    static func request(for target: Target, in context: ModelContext) -> Request {
+        request(for: [target], in: context)
+    }
+
+    static func request(for targets: [Target], in context: ModelContext) -> Request {
+        let graph = deletionGraph(for: targets)
+        let targetTypeIDs = Set(targets.compactMap { target -> UUID? in
+            if case .trainingType(let trainingType) = target { return trainingType.id }
+            return nil
+        })
+        let targetCombinationIDs = Set(targets.compactMap { target -> UUID? in
+            if case .combination(let combination) = target { return combination.id }
+            return nil
+        })
+        let impact = Impact(
+            nodeCount: graph.typeIDs.subtracting(targetTypeIDs).count
+                + graph.combinationIDs.subtracting(targetCombinationIDs).count,
+            exerciseCount: graph.exerciseIDs.count
+        )
+        return Request(targets: targets, impact: impact)
+    }
+
+    static func delete(_ target: Target, in context: ModelContext) throws {
+        try delete([target], in: context)
+    }
+
+    static func delete(_ request: Request, in context: ModelContext) throws {
+        try delete(request.targets, in: context)
+    }
+
+    static func delete(_ targets: [Target], in context: ModelContext) throws {
+        guard !targets.isEmpty else { return }
+
+        let graph = deletionGraph(for: targets)
+        let activities = fetchActivities(in: context)
+        let trainingTypes = fetchTrainingTypes(in: context)
+        let combinations = fetchCombinations(in: context)
+        let exercises = fetchExercises(in: context)
+
+        for activity in activities {
+            activity.types.removeAll { graph.typeIDs.contains($0.id) }
+        }
+        for trainingType in trainingTypes {
+            trainingType.combinations.removeAll { graph.combinationIDs.contains($0.id) }
+            trainingType.exercises.removeAll { graph.exerciseIDs.contains($0.id) && graph.typeIDs.contains(trainingType.id) }
+        }
+        for combination in combinations where graph.combinationIDs.contains(combination.id) {
+            combination.exercises.removeAll { graph.exerciseIDs.contains($0.id) }
+        }
+
+        for combination in combinations where graph.combinationIDs.contains(combination.id) {
+            context.delete(combination)
+        }
+        for trainingType in trainingTypes where graph.typeIDs.contains(trainingType.id) {
+            context.delete(trainingType)
+        }
+        for activity in activities where graph.activityIDs.contains(activity.id) {
+            context.delete(activity)
+        }
+
+        let remainingExerciseIDs = catalogExerciseIDs(in: context)
+        for exercise in exercises where graph.exerciseIDs.contains(exercise.id) && !remainingExerciseIDs.contains(exercise.id) {
+            clearPlanCatalogReferences(for: exercise.id, in: context)
+            context.delete(exercise)
+        }
+
+        removeEmptyImportedContainers(in: context)
+        try context.save()
+    }
+
+    static func deleteExercisePlacement(
+        _ exercise: Exercise,
+        from sourceType: TrainingType?,
+        sourceCombination: BoulderCombination?,
+        in context: ModelContext
+    ) throws {
+        detachExercise(exercise, from: sourceType, sourceCombination: sourceCombination)
+
+        let remainingExerciseIDs = catalogExerciseIDs(in: context)
+        if !remainingExerciseIDs.contains(exercise.id) {
+            clearPlanCatalogReferences(for: exercise.id, in: context)
+            context.delete(exercise)
+        }
+
+        removeEmptyImportedContainers(in: context)
+        try context.save()
+    }
+
+    static func detachExercise(
+        _ exercise: Exercise,
+        from sourceType: TrainingType?,
+        sourceCombination: BoulderCombination?
+    ) {
+        sourceType?.exercises.removeAll { $0.id == exercise.id }
+        sourceCombination?.exercises.removeAll { $0.id == exercise.id }
+    }
+
+    static func removeEmptyImportedContainers(in context: ModelContext) {
+        let activities = fetchActivities(in: context)
+        for activity in activities where normalized(activity.name) == normalized("Imported") {
+            let importedTypes = activity.types.filter { normalized($0.name) == normalized("Imported Plans") }
+            for trainingType in importedTypes where trainingType.exercises.isEmpty && trainingType.combinations.isEmpty {
+                activity.types.removeAll { $0.id == trainingType.id }
+                context.delete(trainingType)
+            }
+
+            if activity.types.isEmpty {
+                context.delete(activity)
+            }
+        }
+    }
+
+    static func exists(_ target: Target, in context: ModelContext) -> Bool {
+        switch target {
+        case .activity(let activity):
+            return fetchActivities(in: context).contains { $0.id == activity.id }
+        case .trainingType(let trainingType):
+            return fetchTrainingTypes(in: context).contains { $0.id == trainingType.id }
+        case .combination(let combination):
+            return fetchCombinations(in: context).contains { $0.id == combination.id }
+        }
+    }
+
+    private struct DeletionGraph {
+        var activityIDs = Set<UUID>()
+        var typeIDs = Set<UUID>()
+        var combinationIDs = Set<UUID>()
+        var exerciseIDs = Set<UUID>()
+    }
+
+    private static func deletionGraph(for targets: [Target]) -> DeletionGraph {
+        let activities = targets.compactMap { target -> Activity? in
+            if case .activity(let activity) = target { return activity }
+            return nil
+        }
+        let trainingTypes = targets.compactMap { target -> TrainingType? in
+            if case .trainingType(let trainingType) = target { return trainingType }
+            return nil
+        }
+        let combinations = targets.compactMap { target -> BoulderCombination? in
+            if case .combination(let combination) = target { return combination }
+            return nil
+        }
+
+        var graph = DeletionGraph()
+        for activity in activities {
+            graph.activityIDs.insert(activity.id)
+            for trainingType in activity.types {
+                graph.typeIDs.insert(trainingType.id)
+                graph.combinationIDs.formUnion(trainingType.combinations.map(\.id))
+                graph.exerciseIDs.formUnion(trainingType.exercises.map(\.id))
+                graph.exerciseIDs.formUnion(trainingType.combinations.flatMap(\.exercises).map(\.id))
+            }
+        }
+        for trainingType in trainingTypes {
+            graph.typeIDs.insert(trainingType.id)
+            graph.combinationIDs.formUnion(trainingType.combinations.map(\.id))
+            graph.exerciseIDs.formUnion(trainingType.exercises.map(\.id))
+            graph.exerciseIDs.formUnion(trainingType.combinations.flatMap(\.exercises).map(\.id))
+        }
+        for combination in combinations {
+            graph.combinationIDs.insert(combination.id)
+            graph.exerciseIDs.formUnion(combination.exercises.map(\.id))
+        }
+        return graph
+    }
+
+    private static func clearPlanCatalogReferences(for exerciseID: UUID, in context: ModelContext) {
+        let definitions = (try? context.fetch(FetchDescriptor<PlanExerciseDefinition>())) ?? []
+        for definition in definitions where definition.catalogExerciseID == exerciseID {
+            definition.catalogExerciseID = nil
+        }
+
+        let days = (try? context.fetch(FetchDescriptor<PlanDay>())) ?? []
+        for day in days {
+            day.chosenExerciseIDs.removeAll { $0 == exerciseID }
+            day.exerciseOrderByID.removeValue(forKey: exerciseID.uuidString)
+        }
+    }
+
+    private static func catalogExerciseIDs(in context: ModelContext) -> Set<UUID> {
+        let activities = fetchActivities(in: context)
+        var ids = Set<UUID>()
+        for activity in activities {
+            for trainingType in activity.types {
+                ids.formUnion(trainingType.exercises.map(\.id))
+                for combination in trainingType.combinations {
+                    ids.formUnion(combination.exercises.map(\.id))
+                }
+            }
+        }
+        return ids
+    }
+
+    private static func fetchActivities(in context: ModelContext) -> [Activity] {
+        (try? context.fetch(FetchDescriptor<Activity>())) ?? []
+    }
+
+    private static func fetchTrainingTypes(in context: ModelContext) -> [TrainingType] {
+        (try? context.fetch(FetchDescriptor<TrainingType>())) ?? []
+    }
+
+    private static func fetchCombinations(in context: ModelContext) -> [BoulderCombination] {
+        (try? context.fetch(FetchDescriptor<BoulderCombination>())) ?? []
+    }
+
+    private static func fetchExercises(in context: ModelContext) -> [Exercise] {
+        (try? context.fetch(FetchDescriptor<Exercise>())) ?? []
+    }
+
+    private static func normalized(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines)
+            .folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current)
+    }
+}

--- a/ClimbingProgram/features/catalog/CatalogReassignment.swift
+++ b/ClimbingProgram/features/catalog/CatalogReassignment.swift
@@ -1,0 +1,183 @@
+import SwiftUI
+import SwiftData
+
+enum CatalogReassignment {
+    struct Destination: Identifiable {
+        enum Kind {
+            case trainingType
+            case combination
+        }
+
+        let id: UUID
+        let activityName: String
+        let typeName: String
+        let name: String
+        let kind: Kind
+        let type: TrainingType
+        let combination: BoulderCombination?
+
+        var label: String {
+            if let combination {
+                return "\(activityName) › \(typeName) › \(combination.name)"
+            }
+            return "\(activityName) › \(typeName)"
+        }
+    }
+
+    static func destinations(in context: ModelContext) -> [Destination] {
+        let activities = (try? context.fetch(FetchDescriptor<Activity>(sortBy: [SortDescriptor(\.name)]))) ?? []
+        return activities.flatMap { activity in
+            activity.types.sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }.flatMap { type in
+                let typeDestination = Destination(id: type.id, activityName: activity.name, typeName: type.name, name: type.name, kind: .trainingType, type: type, combination: nil)
+                let combinations = type.combinations.sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }.map {
+                    Destination(id: $0.id, activityName: activity.name, typeName: type.name, name: $0.name, kind: .combination, type: type, combination: $0)
+                }
+                return [typeDestination] + combinations
+            }
+        }
+    }
+
+    static func move(
+        _ exercise: Exercise,
+        from sourceType: TrainingType?,
+        sourceCombination: BoulderCombination?,
+        to destination: Destination,
+        in context: ModelContext
+    ) throws {
+        try move(
+            [exercise],
+            from: sourceType,
+            sourceCombination: sourceCombination,
+            to: destination,
+            in: context
+        )
+    }
+
+    static func move(
+        _ exercises: [Exercise],
+        from sourceType: TrainingType?,
+        sourceCombination: BoulderCombination?,
+        to destination: Destination,
+        in context: ModelContext
+    ) throws {
+        var seenIDs = Set<UUID>()
+        let uniqueExercises = exercises.filter { seenIDs.insert($0.id).inserted }
+
+        for exercise in uniqueExercises {
+            CatalogDeletion.detachExercise(
+                exercise,
+                from: sourceType,
+                sourceCombination: sourceCombination
+            )
+        }
+
+        if let combination = destination.combination {
+            for exercise in uniqueExercises where !combination.exercises.contains(where: { $0.id == exercise.id }) {
+                combination.exercises.append(exercise)
+            }
+        } else {
+            for exercise in uniqueExercises where !destination.type.exercises.contains(where: { $0.id == exercise.id }) {
+                destination.type.exercises.append(exercise)
+            }
+        }
+
+        CatalogDeletion.removeEmptyImportedContainers(in: context)
+        try context.save()
+    }
+}
+
+struct CatalogExerciseMoveSelection: Identifiable {
+    let id = UUID()
+    let exercises: [Exercise]
+    let sourceType: TrainingType?
+    let sourceCombination: BoulderCombination?
+}
+
+struct CatalogExerciseMoveSheet: View {
+    let exercises: [Exercise]
+    let sourceType: TrainingType?
+    let sourceCombination: BoulderCombination?
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var context
+    @State private var selectedDestination: CatalogReassignment.Destination?
+    @State private var errorMessage: String?
+
+    private var destinations: [CatalogReassignment.Destination] {
+        CatalogReassignment.destinations(in: context).filter { destination in
+            destination.id != sourceType?.id && destination.id != sourceCombination?.id
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            List(destinations) { destination in
+                Button {
+                    selectedDestination = destination
+                } label: {
+                    HStack {
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text(destination.name)
+                                .font(.headline)
+                            Text(destination.label)
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                        if selectedDestination?.id == destination.id {
+                            Image(systemName: "checkmark")
+                                .foregroundStyle(.tint)
+                        }
+                    }
+                }
+                .buttonStyle(.plain)
+            }
+            .navigationTitle(exercises.count == 1 ? "Move Exercise" : "Move Exercises")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Move") {
+                        guard let selectedDestination else { return }
+                        do {
+                            try CatalogReassignment.move(exercises, from: sourceType, sourceCombination: sourceCombination, to: selectedDestination, in: context)
+                            dismiss()
+                        } catch {
+                            errorMessage = error.localizedDescription
+                        }
+                    }
+                    .disabled(selectedDestination == nil)
+                }
+            }
+            .alert("Couldn’t move exercise", isPresented: Binding(
+                get: { errorMessage != nil },
+                set: { if !$0 { errorMessage = nil } }
+            )) {
+                Button("OK", role: .cancel) { }
+            } message: {
+                Text(errorMessage ?? "")
+            }
+        }
+    }
+
+    init(
+        exercise: Exercise,
+        sourceType: TrainingType?,
+        sourceCombination: BoulderCombination?
+    ) {
+        self.exercises = [exercise]
+        self.sourceType = sourceType
+        self.sourceCombination = sourceCombination
+    }
+
+    init(
+        exercises: [Exercise],
+        sourceType: TrainingType?,
+        sourceCombination: BoulderCombination?
+    ) {
+        self.exercises = exercises
+        self.sourceType = sourceType
+        self.sourceCombination = sourceCombination
+    }
+}

--- a/ClimbingProgram/features/catalog/CatalogView.swift
+++ b/ClimbingProgram/features/catalog/CatalogView.swift
@@ -111,6 +111,8 @@ struct CatalogView: View {
     @State private var sheetRoute: SheetRoute?
     @State private var draftActivityName = ""
     @State private var renamingActivity: Activity?
+    @State private var pendingDeletion: CatalogDeletion.Request?
+    @State private var deletionError: String?
 
     // Helper function to count total exercises in an activity
     private func totalExerciseCount(for activity: Activity) -> Int {
@@ -172,6 +174,30 @@ struct CatalogView: View {
         }
         .navigationTitle("CATALOG")
         .navigationBarTitleDisplayMode(.large)
+        .confirmationDialog(
+            pendingDeletion?.title ?? "Delete catalog node?",
+            isPresented: Binding(
+                get: { pendingDeletion != nil },
+                set: { if !$0 { pendingDeletion = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("Delete", role: .destructive) {
+                guard let request = pendingDeletion else { return }
+                performDeletion(request)
+            }
+            Button("Cancel", role: .cancel) { pendingDeletion = nil }
+        } message: {
+            Text(pendingDeletion?.message ?? "")
+        }
+        .alert("Couldn’t delete catalog node", isPresented: Binding(
+            get: { deletionError != nil },
+            set: { if !$0 { deletionError = nil } }
+        )) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text(deletionError ?? "")
+        }
     }
     
     private func activityCard(for activity: Activity) -> some View {
@@ -198,11 +224,28 @@ struct CatalogView: View {
             }
             Button(role: .destructive) {
                 guard isDataReady else { return }
-                context.delete(activity)
-                try? context.save()
+                requestDeletion(for: .activity(activity))
             } label: {
                 Label("Delete", systemImage: "trash")
             }
+        }
+    }
+
+    private func requestDeletion(for target: CatalogDeletion.Target) {
+        let request = CatalogDeletion.request(for: target, in: context)
+        if request.impact.isEmpty {
+            performDeletion(request)
+        } else {
+            pendingDeletion = request
+        }
+    }
+
+    private func performDeletion(_ request: CatalogDeletion.Request) {
+        pendingDeletion = nil
+        do {
+            try CatalogDeletion.delete(request, in: context)
+        } catch {
+            deletionError = error.localizedDescription
         }
     }
 }
@@ -224,6 +267,8 @@ struct ActivityDetailView: View {
     @State private var draftArea = ""
     @State private var draftTypeDesc = ""
     @State private var renamingType: TrainingType?
+    @State private var pendingDeletion: CatalogDeletion.Request?
+    @State private var deletionError: String?
 
     var body: some View {
         List {
@@ -249,11 +294,7 @@ struct ActivityDetailView: View {
                         }
                         Button(role: .destructive) {
                             guard isDataReady else { return }
-
-                            activity.types.removeAll { $0.id == t.id }
-
-                            context.delete(t)
-                            try? context.save()
+                            requestDeletion(for: .trainingType(t))
                         } label: { Label("Delete", systemImage: "trash") }
 
                     }
@@ -261,12 +302,7 @@ struct ActivityDetailView: View {
                 .onDelete { idx in
                     guard isDataReady else { return }
                     let toDelete = idx.map { activity.types[$0] }
-                    let ids = Set(toDelete.map(\.id))
-
-                    activity.types.removeAll { ids.contains($0.id) }
-
-                    toDelete.forEach { context.delete($0) }
-                    try? context.save()
+                    requestDeletion(for: toDelete.map(CatalogDeletion.Target.trainingType))
                 }
 
 
@@ -288,6 +324,30 @@ struct ActivityDetailView: View {
             ToolbarItem(placement: .topBarLeading) {
                 EditButton()
             }
+        }
+        .confirmationDialog(
+            pendingDeletion?.title ?? "Delete catalog node?",
+            isPresented: Binding(
+                get: { pendingDeletion != nil },
+                set: { if !$0 { pendingDeletion = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("Delete", role: .destructive) {
+                guard let request = pendingDeletion else { return }
+                performDeletion(request)
+            }
+            Button("Cancel", role: .cancel) { pendingDeletion = nil }
+        } message: {
+            Text(pendingDeletion?.message ?? "")
+        }
+        .alert("Couldn’t delete catalog node", isPresented: Binding(
+            get: { deletionError != nil },
+            set: { if !$0 { deletionError = nil } }
+        )) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text(deletionError ?? "")
         }
 
         // Create Type
@@ -326,6 +386,29 @@ struct ActivityDetailView: View {
             }
         }
     }
+
+    private func requestDeletion(for target: CatalogDeletion.Target) {
+        requestDeletion(for: [target])
+    }
+
+    private func requestDeletion(for targets: [CatalogDeletion.Target]) {
+        guard !targets.isEmpty else { return }
+        let request = CatalogDeletion.request(for: targets, in: context)
+        if request.impact.isEmpty {
+            performDeletion(request)
+        } else {
+            pendingDeletion = request
+        }
+    }
+
+    private func performDeletion(_ request: CatalogDeletion.Request) {
+        pendingDeletion = nil
+        do {
+            try CatalogDeletion.delete(request, in: context)
+        } catch {
+            deletionError = error.localizedDescription
+        }
+    }
 }
 
 // MARK: - Type detail (Exercises or Bouldering combinations)
@@ -339,11 +422,18 @@ struct TrainingTypeDetailView: View {
     }
 
     @Environment(\.modelContext) private var context
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.editMode) private var editMode
     @Bindable var trainingType: TrainingType
     let tint: Color
 
     @State private var modalRoute: ModalRoute?
     @State private var editingExercise: Exercise?
+    @State private var movingExercise: Exercise?
+    @State private var bulkMoveRequest: CatalogExerciseMoveSelection?
+    @State private var selectedExerciseIDs = Set<UUID>()
+    @State private var pendingDeletion: CatalogDeletion.Request?
+    @State private var deletionError: String?
 
     // Drafts
     @State private var draftExName = ""
@@ -378,6 +468,10 @@ struct TrainingTypeDetailView: View {
     private var ungroupedExercises: [Exercise] {
         trainingType.exercises.filter { $0.area == nil }.sorted { $0.order < $1.order }
     }
+
+    private var selectedExercises: [Exercise] {
+        trainingType.exercises.filter { selectedExerciseIDs.contains($0.id) }
+    }
     
     // Define available areas for climbing exercises
     private var availableAreas: [String] {
@@ -391,7 +485,7 @@ struct TrainingTypeDetailView: View {
     }
 
     var body: some View {
-        List {
+        List(selection: $selectedExerciseIDs) {
             if let d = trainingType.typeDescription, !d.isEmpty {
                 Section("About") {
                     Text(d).textCase(nil)
@@ -411,6 +505,13 @@ struct TrainingTypeDetailView: View {
                                 }
                             }
                         }
+                        .contextMenu {
+                            Button(role: .destructive) {
+                                requestDeletion(for: .combination(combo))
+                            } label: {
+                                Label("Delete", systemImage: "trash")
+                            }
+                        }
                     }
                     .textCase(nil)
                 }
@@ -428,29 +529,31 @@ struct TrainingTypeDetailView: View {
                                     .contentShape(Rectangle())
                             }
                             .buttonStyle(.plain)
-                                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                                    Button(role: .destructive) {
-                                        // Update UI immediately (source-of-truth is trainingType.exercises)
-                                        trainingType.exercises.removeAll { $0.id == ex.id }
-
-                                        // Persist
-                                        context.delete(ex)
-                                        try? context.save()
-                                    } label: {
-                                        Label("Delete", systemImage: "trash")
-                                    }
+                            .contextMenu {
+                                Button {
+                                    movingExercise = ex
+                                } label: {
+                                    Label("Move to…", systemImage: "folder")
                                 }
+                            }
+                            .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                                Button {
+                                    movingExercise = ex
+                                } label: {
+                                    Label("Move", systemImage: "arrow.up.and.down")
+                                }
+                                .tint(.blue)
+                                Button(role: .destructive) {
+                                    deleteExercise(ex)
+                                } label: {
+                                    Label("Delete", systemImage: "trash")
+                                }
+                            }
+                            .tag(ex.id)
                         }
                         .onDelete { indexes in
                             let toDelete = indexes.map { exercises[$0] }
-                            let ids = Set(toDelete.map(\.id))
-
-                            // Update UI immediately
-                            trainingType.exercises.removeAll { ids.contains($0.id) }
-
-                            // Persist
-                            toDelete.forEach { context.delete($0) }
-                            try? context.save()
+                            deleteExercises(toDelete)
                         }
 
                     }
@@ -468,25 +571,32 @@ struct TrainingTypeDetailView: View {
                                 .contentShape(Rectangle())
                         }
                         .buttonStyle(.plain)
-                            .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                                Button(role: .destructive) {
-                                    trainingType.exercises.removeAll { $0.id == ex.id }
-                                    context.delete(ex)
-                                    try? context.save()
-                                } label: {
-                                    Label("Delete", systemImage: "trash")
-                                }
+                        .contextMenu {
+                            Button {
+                                movingExercise = ex
+                            } label: {
+                                Label("Move to…", systemImage: "folder")
                             }
+                        }
+                        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                            Button {
+                                movingExercise = ex
+                            } label: {
+                                Label("Move", systemImage: "arrow.up.and.down")
+                            }
+                            .tint(.blue)
+                            Button(role: .destructive) {
+                                deleteExercise(ex)
+                            } label: {
+                                Label("Delete", systemImage: "trash")
+                            }
+                        }
+                        .tag(ex.id)
 
                     }
                     .onDelete { indexes in
                         let toDelete = indexes.map { ungroupedExercises[$0] }
-                        let ids = Set(toDelete.map(\.id))
-
-                        trainingType.exercises.removeAll { ids.contains($0.id) }
-
-                        toDelete.forEach { context.delete($0) }
-                        try? context.save()
+                        deleteExercises(toDelete)
                     }
 
                 }
@@ -510,6 +620,55 @@ struct TrainingTypeDetailView: View {
                     modalRoute = .editAbout
                 }
             }
+            ToolbarItem(placement: .topBarTrailing) {
+                Button(role: .destructive) {
+                    requestDeletion(for: .trainingType(trainingType))
+                } label: {
+                    Label("Delete Training Type", systemImage: "trash")
+                }
+            }
+            if !selectedExerciseIDs.isEmpty {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        bulkMoveRequest = CatalogExerciseMoveSelection(
+                            exercises: selectedExercises,
+                            sourceType: trainingType,
+                            sourceCombination: nil
+                        )
+                    } label: {
+                        Label("Move Selected", systemImage: "arrow.up.and.down")
+                    }
+                }
+            }
+        }
+        .onChange(of: editMode?.wrappedValue) { _, newValue in
+            if newValue != .active {
+                selectedExerciseIDs.removeAll()
+            }
+        }
+        .confirmationDialog(
+            pendingDeletion?.title ?? "Delete catalog node?",
+            isPresented: Binding(
+                get: { pendingDeletion != nil },
+                set: { if !$0 { pendingDeletion = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("Delete", role: .destructive) {
+                guard let request = pendingDeletion else { return }
+                performDeletion(request)
+            }
+            Button("Cancel", role: .cancel) { pendingDeletion = nil }
+        } message: {
+            Text(pendingDeletion?.message ?? "")
+        }
+        .alert("Couldn’t delete catalog item", isPresented: Binding(
+            get: { deletionError != nil },
+            set: { if !$0 { deletionError = nil } }
+        )) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text(deletionError ?? "")
         }
         .sheet(item: $modalRoute) { route in
             switch route {
@@ -588,6 +747,18 @@ struct TrainingTypeDetailView: View {
                 }
             }
         }
+        .sheet(item: $movingExercise) { ex in
+            CatalogExerciseMoveSheet(exercise: ex, sourceType: trainingType, sourceCombination: nil)
+        }
+        .sheet(item: $bulkMoveRequest, onDismiss: {
+            selectedExerciseIDs.removeAll()
+        }) { request in
+            CatalogExerciseMoveSheet(
+                exercises: request.exercises,
+                sourceType: request.sourceType,
+                sourceCombination: request.sourceCombination
+            )
+        }
     }
 
     private func startNewExercise() {
@@ -605,6 +776,55 @@ struct TrainingTypeDetailView: View {
         draftNotes = ex.notes ?? ""
         editingExercise = ex
     }
+
+    private func requestDeletion(for target: CatalogDeletion.Target) {
+        let request = CatalogDeletion.request(for: target, in: context)
+        if request.impact.isEmpty {
+            performDeletion(request)
+        } else {
+            pendingDeletion = request
+        }
+    }
+
+    private func performDeletion(_ request: CatalogDeletion.Request) {
+        pendingDeletion = nil
+        do {
+            let deletesCurrentType = request.targets.contains { target in
+                if case .trainingType(let targetType) = target {
+                    return targetType.id == trainingType.id
+                }
+                return false
+            }
+            try CatalogDeletion.delete(request, in: context)
+            if deletesCurrentType || !CatalogDeletion.exists(.trainingType(trainingType), in: context) {
+                dismiss()
+            }
+        } catch {
+            deletionError = error.localizedDescription
+        }
+    }
+
+    private func deleteExercise(_ exercise: Exercise) {
+        do {
+            try CatalogDeletion.deleteExercisePlacement(
+                exercise,
+                from: trainingType,
+                sourceCombination: nil,
+                in: context
+            )
+            if !CatalogDeletion.exists(.trainingType(trainingType), in: context) {
+                dismiss()
+            }
+        } catch {
+            deletionError = error.localizedDescription
+        }
+    }
+
+    private func deleteExercises(_ exercises: [Exercise]) {
+        for exercise in exercises {
+            deleteExercise(exercise)
+        }
+    }
 }
 
 // MARK: - Combination detail (Bouldering)
@@ -618,11 +838,18 @@ struct CombinationDetailView: View {
     }
 
     @Environment(\.modelContext) private var context
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.editMode) private var editMode
     @Bindable var combo: BoulderCombination
     let tint: Color
 
     @State private var editingExercise: Exercise?
     @State private var modalRoute: ModalRoute?
+    @State private var movingExercise: Exercise?
+    @State private var bulkMoveRequest: CatalogExerciseMoveSelection?
+    @State private var selectedExerciseIDs = Set<UUID>()
+    @State private var pendingDeletion: CatalogDeletion.Request?
+    @State private var deletionError: String?
 
     @State private var draftExName = ""
     @State private var draftArea = ""
@@ -634,9 +861,12 @@ struct CombinationDetailView: View {
     @State private var draftDesc = ""
     @State private var draftAbout = ""
 
+    private var selectedExercises: [Exercise] {
+        combo.exercises.filter { selectedExerciseIDs.contains($0.id) }
+    }
 
     var body: some View {
-        List {
+        List(selection: $selectedExerciseIDs) {
             if let about = combo.comboDescription, !about.isEmpty {
                 Section("About") { Text(about) }
             }
@@ -649,34 +879,40 @@ struct CombinationDetailView: View {
                             .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
-                        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                            Button(role: .destructive) {
-                                combo.exercises.removeAll { $0.id == ex.id }
-                                context.delete(ex)
-                                try? context.save()
-                            } label: { Label("Delete", systemImage: "trash") }
-
+                    .contextMenu {
+                        Button {
+                            movingExercise = ex
+                        } label: {
+                            Label("Move to…", systemImage: "folder")
                         }
+                    }
+                    .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                        Button {
+                            movingExercise = ex
+                        } label: {
+                            Label("Move", systemImage: "arrow.up.and.down")
+                        }
+                        .tint(.blue)
+                        Button(role: .destructive) {
+                            deleteExercise(ex)
+                        } label: {
+                            Label("Delete", systemImage: "trash")
+                        }
+                    }
                         .contextMenu {
                             Button(role: .destructive) {
-                                combo.exercises.removeAll { $0.id == ex.id }
-                                context.delete(ex)
-                                try? context.save()
+                                deleteExercise(ex)
                             } label: {
                                 Label("Delete", systemImage: "trash")
                             }
 
                         }
+                    .tag(ex.id)
                 }
                 .onDelete { idx in
                     let sortedExercises = combo.exercises.sorted { $0.order < $1.order }
                     let toDelete = idx.map { sortedExercises[$0] }
-                    let ids = Set(toDelete.map(\.id))
-
-                    combo.exercises.removeAll { ids.contains($0.id) }
-
-                    toDelete.forEach { context.delete($0) }
-                    try? context.save()
+                    deleteExercises(toDelete)
                 }
 
 
@@ -697,6 +933,55 @@ struct CombinationDetailView: View {
                     modalRoute = .editAbout
                 }
             }
+            ToolbarItem(placement: .topBarTrailing) {
+                Button(role: .destructive) {
+                    requestDeletion(for: .combination(combo))
+                } label: {
+                    Label("Delete Combination", systemImage: "trash")
+                }
+            }
+            if !selectedExerciseIDs.isEmpty {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        bulkMoveRequest = CatalogExerciseMoveSelection(
+                            exercises: selectedExercises,
+                            sourceType: nil,
+                            sourceCombination: combo
+                        )
+                    } label: {
+                        Label("Move Selected", systemImage: "arrow.up.and.down")
+                    }
+                }
+            }
+        }
+        .onChange(of: editMode?.wrappedValue) { _, newValue in
+            if newValue != .active {
+                selectedExerciseIDs.removeAll()
+            }
+        }
+        .confirmationDialog(
+            pendingDeletion?.title ?? "Delete catalog node?",
+            isPresented: Binding(
+                get: { pendingDeletion != nil },
+                set: { if !$0 { pendingDeletion = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("Delete", role: .destructive) {
+                guard let request = pendingDeletion else { return }
+                performDeletion(request)
+            }
+            Button("Cancel", role: .cancel) { pendingDeletion = nil }
+        } message: {
+            Text(pendingDeletion?.message ?? "")
+        }
+        .alert("Couldn’t delete catalog item", isPresented: Binding(
+            get: { deletionError != nil },
+            set: { if !$0 { deletionError = nil } }
+        )) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text(deletionError ?? "")
         }
         .sheet(item: $modalRoute) { route in
             switch route {
@@ -775,6 +1060,18 @@ struct CombinationDetailView: View {
                 }
             }
         }
+        .sheet(item: $movingExercise) { ex in
+            CatalogExerciseMoveSheet(exercise: ex, sourceType: nil, sourceCombination: combo)
+        }
+        .sheet(item: $bulkMoveRequest, onDismiss: {
+            selectedExerciseIDs.removeAll()
+        }) { request in
+            CatalogExerciseMoveSheet(
+                exercises: request.exercises,
+                sourceType: request.sourceType,
+                sourceCombination: request.sourceCombination
+            )
+        }
     }
 
     private func startNewExercise() {
@@ -791,6 +1088,46 @@ struct CombinationDetailView: View {
         draftRest = ex.restText ?? ""
         draftNotes = ex.notes ?? ""
         editingExercise = ex
+    }
+
+    private func requestDeletion(for target: CatalogDeletion.Target) {
+        let request = CatalogDeletion.request(for: target, in: context)
+        if request.impact.isEmpty {
+            performDeletion(request)
+        } else {
+            pendingDeletion = request
+        }
+    }
+
+    private func performDeletion(_ request: CatalogDeletion.Request) {
+        pendingDeletion = nil
+        do {
+            try CatalogDeletion.delete(request, in: context)
+            if !CatalogDeletion.exists(.combination(combo), in: context) {
+                dismiss()
+            }
+        } catch {
+            deletionError = error.localizedDescription
+        }
+    }
+
+    private func deleteExercise(_ exercise: Exercise) {
+        do {
+            try CatalogDeletion.deleteExercisePlacement(
+                exercise,
+                from: nil,
+                sourceCombination: combo,
+                in: context
+            )
+        } catch {
+            deletionError = error.localizedDescription
+        }
+    }
+
+    private func deleteExercises(_ exercises: [Exercise]) {
+        for exercise in exercises {
+            deleteExercise(exercise)
+        }
     }
 }
 

--- a/ClimbingProgram/features/plans/PlanExchangeViews.swift
+++ b/ClimbingProgram/features/plans/PlanExchangeViews.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+import SwiftData
+
+struct PendingPlanImport: Identifiable {
+    let id = UUID()
+    let exchange: PlanCSVExchange.ParsedExchange
+    let mode: PlanCSVExchange.ImportMode
+
+    var targetDescription: String {
+        switch mode {
+        case .newPlan: return "Create a new plan"
+        case .existing(let plan): return "Update \(plan.name)"
+        }
+    }
+}
+
+struct PlanImportPreviewSheet: View {
+    let pending: PendingPlanImport
+    let onComplete: (Result<PlanCSVExchange.Summary, Error>) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var context
+    @State private var isApplying = false
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Import") {
+                    LabeledContent("Plan", value: pending.exchange.plan.name)
+                    LabeledContent("Action", value: pending.targetDescription)
+                    LabeledContent("Days", value: pending.exchange.days.count.formatted())
+                    LabeledContent("Exercises", value: pending.exchange.exercises.count.formatted())
+                    LabeledContent("Exercise logs", value: pending.exchange.logs.count.formatted())
+                    LabeledContent("Climbs", value: pending.exchange.climbs.count.formatted())
+                }
+
+                Section {
+                    Text("Already logged exercises, climbs, and non-empty day context will be preserved. Unlogged schedule changes from the CSV will be applied.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+
+                if !pending.exchange.warnings.isEmpty {
+                    Section("Warnings") {
+                        ForEach(Array(pending.exchange.warnings.enumerated()), id: \.offset) { _, warning in
+                            Text(warning)
+                                .font(.footnote)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Review Plan Import")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .disabled(isApplying)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Import") {
+                        applyImport()
+                    }
+                    .disabled(isApplying)
+                }
+            }
+            .overlay {
+                if isApplying {
+                    ProgressView("Importing…")
+                        .padding()
+                        .background(.regularMaterial, in: .rect(cornerRadius: 12))
+                    }
+                }
+            }
+        }
+
+    private func applyImport() {
+        isApplying = true
+        do {
+            let summary = try PlanCSVExchange.apply(pending.exchange, mode: pending.mode, in: context)
+            onComplete(.success(summary))
+            dismiss()
+        } catch {
+            isApplying = false
+            onComplete(.failure(error))
+        }
+    }
+}

--- a/ClimbingProgram/features/plans/PlanExchangeViews.swift
+++ b/ClimbingProgram/features/plans/PlanExchangeViews.swift
@@ -21,6 +21,7 @@ struct PlanImportPreviewSheet: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) private var context
     @State private var isApplying = false
+    @State private var overwriteDayContext = false
 
     var body: some View {
         NavigationStack {
@@ -34,8 +35,17 @@ struct PlanImportPreviewSheet: View {
                     LabeledContent("Climbs", value: pending.exchange.climbs.count.formatted())
                 }
 
+                if !pending.exchange.contexts.isEmpty {
+                    Section("Day context") {
+                        Toggle("Overwrite existing day context", isOn: $overwriteDayContext)
+                        Text("When enabled, notes and tags from the CSV replace the existing context for those dates. When disabled, CSV day context is ignored.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
                 Section {
-                    Text("Already logged exercises, climbs, and non-empty day context will be preserved. Unlogged schedule changes from the CSV will be applied.")
+                    Text("Only logged exercises and linked climbs are protected. Other plan metadata and schedule changes from the CSV will be applied.")
                         .font(.footnote)
                         .foregroundStyle(.secondary)
                 }
@@ -75,7 +85,12 @@ struct PlanImportPreviewSheet: View {
     private func applyImport() {
         isApplying = true
         do {
-            let summary = try PlanCSVExchange.apply(pending.exchange, mode: pending.mode, in: context)
+            let summary = try PlanCSVExchange.apply(
+                pending.exchange,
+                mode: pending.mode,
+                overwriteDayContext: overwriteDayContext,
+                in: context
+            )
             onComplete(.success(summary))
             dismiss()
         } catch {

--- a/ClimbingProgram/features/plans/PlanExchangeViews.swift
+++ b/ClimbingProgram/features/plans/PlanExchangeViews.swift
@@ -23,36 +23,35 @@ struct PlanImportPreviewSheet: View {
     @State private var isApplying = false
     @State private var overwriteDayContext = false
 
+    private var importPreview: PlanCSVExchange.ImportPreview {
+        PlanCSVExchange.preview(
+            pending.exchange,
+            mode: pending.mode,
+            overwriteDayContext: overwriteDayContext,
+            in: context
+        )
+    }
+
     var body: some View {
         NavigationStack {
             Form {
-                Section("Import") {
-                    LabeledContent("Plan", value: pending.exchange.plan.name)
-                    LabeledContent("Action", value: pending.targetDescription)
-                    LabeledContent("Days", value: pending.exchange.days.count.formatted())
-                    LabeledContent("Exercises", value: pending.exchange.exercises.count.formatted())
-                    LabeledContent("Exercise logs", value: pending.exchange.logs.count.formatted())
-                    LabeledContent("Climbs", value: pending.exchange.climbs.count.formatted())
-                }
+                PlanImportChangeSections(preview: importPreview)
 
                 if !pending.exchange.contexts.isEmpty {
                     Section("Day context") {
                         Toggle("Overwrite existing day context", isOn: $overwriteDayContext)
+                        ImportCountRow(label: "Rows in CSV", count: importPreview.dayContextRows)
+                        ImportCountRow(label: "Rows to overwrite", count: importPreview.dayContextRowsToApply)
+                        ImportCountRow(label: "Rows to ignore", count: importPreview.dayContextRowsIgnored)
                         Text("When enabled, notes and tags from the CSV replace the existing context for those dates. When disabled, CSV day context is ignored.")
                             .font(.footnote)
                             .foregroundStyle(.secondary)
                     }
                 }
 
-                Section {
-                    Text("Only logged exercises and linked climbs are protected. Other plan metadata and schedule changes from the CSV will be applied.")
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
-                }
-
-                if !pending.exchange.warnings.isEmpty {
+                if !importPreview.warnings.isEmpty {
                     Section("Warnings") {
-                        ForEach(Array(pending.exchange.warnings.enumerated()), id: \.offset) { _, warning in
+                        ForEach(Array(importPreview.warnings.enumerated()), id: \.offset) { _, warning in
                             Text(warning)
                                 .font(.footnote)
                         }
@@ -97,5 +96,102 @@ struct PlanImportPreviewSheet: View {
             isApplying = false
             onComplete(.failure(error))
         }
+    }
+}
+
+struct PlanImportSummarySheet: View {
+    let summary: PlanCSVExchange.Summary
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    Text(summary.preview.isNewPlan ? "New plan created" : "Existing plan updated")
+                        .font(.headline)
+                    LabeledContent("Plan", value: summary.planName)
+                }
+
+                PlanImportChangeSections(preview: summary.preview, summary: summary)
+
+                Section("Day context") {
+                    ImportCountRow(label: "Rows overwritten", count: summary.dayContextCountApplied)
+                    ImportCountRow(label: "Rows ignored", count: summary.dayContextCountIgnored)
+                }
+
+                if !summary.warnings.isEmpty {
+                    Section("Warnings") {
+                        ForEach(Array(summary.warnings.enumerated()), id: \.offset) { _, warning in
+                            Text(warning)
+                                .font(.footnote)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Plan Import Complete")
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+}
+
+private struct PlanImportChangeSections: View {
+    let preview: PlanCSVExchange.ImportPreview
+    var summary: PlanCSVExchange.Summary?
+
+    var body: some View {
+        Section("Plan") {
+            LabeledContent("Plan", value: preview.planName)
+            if preview.isNewPlan {
+                LabeledContent("Action", value: "Create new plan")
+            } else {
+                LabeledContent("Target", value: preview.targetPlanName)
+                if preview.metadataChanges.isEmpty {
+                    LabeledContent("Metadata", value: "No changes")
+                } else {
+                    ForEach(preview.metadataChanges, id: \.self) { change in
+                        LabeledContent(change, value: "Updated")
+                    }
+                }
+            }
+        }
+
+        Section("Schedule") {
+            ImportCountRow(label: "Days added", count: preview.daysToAdd)
+            ImportCountRow(label: "Days updated", count: preview.daysToUpdate)
+            ImportCountRow(label: "Unlogged days removed", count: preview.daysToRemove)
+            ImportCountRow(label: "Days with protected records", count: preview.protectedDayCount)
+            ImportCountRow(label: "Schedule entries added", count: preview.scheduleEntriesToAdd)
+            ImportCountRow(label: "Unlogged schedule entries removed", count: preview.scheduleEntriesToRemove)
+        }
+
+        Section("Exercises") {
+            ImportCountRow(label: "Definitions added", count: preview.exerciseDefinitionsToAdd)
+            ImportCountRow(label: "Definitions updated", count: preview.exerciseDefinitionsToUpdate)
+            ImportCountRow(label: "Logged exercises protected", count: preview.protectedLoggedExerciseCount)
+            if preview.missingCatalogExerciseCount > 0 {
+                ImportCountRow(label: "Missing catalog exercises", count: preview.missingCatalogExerciseCount)
+            }
+        }
+
+        Section("Logs and climbs") {
+            ImportCountRow(label: summary == nil ? "Logs to import" : "Logs imported", count: summary?.logCount ?? preview.logsToImport)
+            ImportCountRow(label: "Existing logs preserved", count: preview.existingLogCount)
+            ImportCountRow(label: summary == nil ? "Climbs to import" : "Climbs imported", count: summary?.climbCount ?? preview.climbsToImport)
+            ImportCountRow(label: "Linked climbs preserved", count: preview.existingClimbCount)
+        }
+    }
+}
+
+private struct ImportCountRow: View {
+    let label: String
+    let count: Int
+
+    var body: some View {
+        LabeledContent(label, value: count.formatted())
     }
 }

--- a/ClimbingProgram/features/plans/PlansViews.swift
+++ b/ClimbingProgram/features/plans/PlansViews.swift
@@ -353,6 +353,17 @@ struct PlansListView: View {
     private func handlePlanImportResult(_ result: Result<[URL], Error>) {
         do {
             guard let url = try result.get().first else { return }
+
+            // Files selected from Files.app may be outside the app sandbox. The
+            // simulator often permits direct reads, but physical devices require
+            // the security-scoped URL access granted by fileImporter.
+            let didAccessSecurityScopedResource = url.startAccessingSecurityScopedResource()
+            defer {
+                if didAccessSecurityScopedResource {
+                    url.stopAccessingSecurityScopedResource()
+                }
+            }
+
             let data = try Data(contentsOf: url)
             let exchange = try PlanCSVExchange.parse(String(decoding: data, as: UTF8.self))
             let mode: PlanCSVExchange.ImportMode = if let target = planImportTarget {

--- a/ClimbingProgram/features/plans/PlansViews.swift
+++ b/ClimbingProgram/features/plans/PlansViews.swift
@@ -124,6 +124,12 @@ struct PlansListView: View {
     @State private var showExporter = false
     @State private var exportDoc: LogCSVDocument? = nil
 
+    @State private var showPlanExporter = false
+    @State private var planExportDoc: PlanCSVDocument? = nil
+    @State private var showPlanImporter = false
+    @State private var planImportTarget: Plan? = nil
+    @State private var pendingPlanImport: PendingPlanImport? = nil
+
     // Import (async with progress)
     @State private var showImporter = false
     @State private var importing = false
@@ -172,6 +178,7 @@ struct PlansListView: View {
                     showExporter: $showExporter,
                     exportDoc: $exportDoc,
                     showImporter: $showImporter,
+                    showPlanImporter: $showPlanImporter,
                     sharePayload: $sharePayload,
                     resultMessage: $resultMessage
                 )
@@ -194,12 +201,42 @@ struct PlansListView: View {
                         resultMessage = "Export failed: \(err.localizedDescription)"
                     }
                 }
+                .fileExporter(
+                    isPresented: $showPlanExporter,
+                    document: planExportDoc,
+                    contentType: .commaSeparatedText,
+                    defaultFilename: "klettrack-plan-\(Date().formatted(.dateTime.year().month().day()))"
+                ) { result in
+                    switch result {
+                    case .success:
+                        resultMessage = "Plan CSV exported."
+                    case .failure(let error):
+                        resultMessage = "Plan export failed: \(error.localizedDescription)"
+                    }
+                }
                 .fileImporter(
                     isPresented: $showImporter,
                     allowedContentTypes: [.commaSeparatedText],
                     allowsMultipleSelection: false
                 ) { result in
                     handleImportResult(result)
+                }
+                .fileImporter(
+                    isPresented: $showPlanImporter,
+                    allowedContentTypes: [.commaSeparatedText],
+                    allowsMultipleSelection: false
+                ) { result in
+                    handlePlanImportResult(result)
+                }
+                .sheet(item: $pendingPlanImport) { pending in
+                    PlanImportPreviewSheet(pending: pending) { result in
+                        switch result {
+                        case .success(let summary):
+                            resultMessage = summary.message
+                        case .failure(let error):
+                            resultMessage = "Plan import failed: \(error.localizedDescription)"
+                        }
+                    }
                 }
                 .sheet(item: $sharePayload) { payload in
                     ShareSheet(items: [payload.url]) {
@@ -219,12 +256,49 @@ struct PlansListView: View {
     private var plansList: some View {
         List {
             ForEach(plans) { plan in
-                Button {
-                    timerAppState.plansNavigationPath.append(PlanNavigationItem(plan: plan))
-                } label: {
-                    PlanRow(plan: plan)
+                HStack(spacing: 12) {
+                    Button {
+                        timerAppState.plansNavigationPath.append(PlanNavigationItem(plan: plan))
+                    } label: {
+                        PlanRow(plan: plan)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .buttonStyle(.plain)
+
+                    Menu {
+                        Button {
+                            planExportDoc = PlanCSVExchange.export(plan: plan, in: context)
+                            showPlanExporter = true
+                        } label: {
+                            Label("Export Plan", systemImage: "square.and.arrow.up")
+                        }
+
+                        Button {
+                            planImportTarget = plan
+                            showPlanImporter = true
+                        } label: {
+                            Label("Import into this plan", systemImage: "square.and.arrow.down")
+                        }
+                    } label: {
+                        Image(systemName: "ellipsis.circle")
+                            .accessibilityLabel("Plan actions")
+                    }
                 }
-                .buttonStyle(.plain)
+                .contextMenu {
+                    Button {
+                        planExportDoc = PlanCSVExchange.export(plan: plan, in: context)
+                        showPlanExporter = true
+                    } label: {
+                        Label("Export Plan", systemImage: "square.and.arrow.up")
+                    }
+
+                    Button {
+                        planImportTarget = plan
+                        showPlanImporter = true
+                    } label: {
+                        Label("Import into this plan", systemImage: "square.and.arrow.down")
+                    }
+                }
             }
             .onDelete { idx in
                 guard isDataReady else { return }
@@ -270,6 +344,24 @@ struct PlansListView: View {
             }
         } catch {
             resultMessage = "Import failed: \(error.localizedDescription)"
+        }
+    }
+
+    private func handlePlanImportResult(_ result: Result<[URL], Error>) {
+        do {
+            guard let url = try result.get().first else { return }
+            let data = try Data(contentsOf: url)
+            let exchange = try PlanCSVExchange.parse(String(decoding: data, as: UTF8.self))
+            let mode: PlanCSVExchange.ImportMode = if let target = planImportTarget {
+                .existing(target)
+            } else {
+                .newPlan
+            }
+            pendingPlanImport = PendingPlanImport(exchange: exchange, mode: mode)
+            planImportTarget = nil
+        } catch {
+            resultMessage = "Plan import failed: \(error.localizedDescription)"
+            planImportTarget = nil
         }
     }
 }
@@ -331,6 +423,7 @@ private struct PlansToolbarModifier: ViewModifier {
     @Binding var showExporter: Bool
     @Binding var exportDoc: LogCSVDocument?
     @Binding var showImporter: Bool
+    @Binding var showPlanImporter: Bool
     @Binding var sharePayload: SharePayload?
     @Binding var resultMessage: String?
 
@@ -343,7 +436,7 @@ private struct PlansToolbarModifier: ViewModifier {
                         exportDoc = LogCSV.makeExportCSV(context: context)
                         showExporter = true
                     } label: {
-                        Label("Export logs to CSV", systemImage: "square.and.arrow.up")
+                        Label("Export Logs", systemImage: "square.and.arrow.up")
                     }
 
                     Button {
@@ -363,14 +456,21 @@ private struct PlansToolbarModifier: ViewModifier {
                             resultMessage = "Share prep failed: \(error.localizedDescription)"
                         }
                     } label: {
-                        Label("Share logs (CSV)…", systemImage: "square.and.arrow.up.on.square")
+                        Label("Share Logs", systemImage: "square.and.arrow.up.on.square")
                     }
 
                     Button {
                         guard isDataReady else { return }
                         showImporter = true
                     } label: {
-                        Label("Import logs from CSV", systemImage: "square.and.arrow.down")
+                        Label("Import Logs", systemImage: "square.and.arrow.down")
+                    }
+
+                    Button {
+                        guard isDataReady else { return }
+                        showPlanImporter = true
+                    } label: {
+                        Label("Import New Plan", systemImage: "arrow.down.document")
                     }
                 } label: {
                     Image(systemName: "ellipsis.circle")
@@ -399,6 +499,7 @@ private extension View {
         showExporter: Binding<Bool>,
         exportDoc: Binding<LogCSVDocument?>,
         showImporter: Binding<Bool>,
+        showPlanImporter: Binding<Bool>,
         sharePayload: Binding<SharePayload?>,
         resultMessage: Binding<String?>
     ) -> some View {
@@ -409,6 +510,7 @@ private extension View {
             showExporter: showExporter,
             exportDoc: exportDoc,
             showImporter: showImporter,
+            showPlanImporter: showPlanImporter,
             sharePayload: sharePayload,
             resultMessage: resultMessage
         ))
@@ -1615,6 +1717,20 @@ struct PlanDayEditor: View {
         let plans = (try? context.fetch(planDesc)) ?? []
         cache.parentPlan = plans.first { $0.days.contains(where: { $0.id == day.id }) }
 
+        // Imported plans may carry guidance that intentionally differs from
+        // the global catalog. Prefer the plan-local definition for this view.
+        if let parentPlan = cache.parentPlan {
+            for definition in parentPlan.exerciseDefinitions {
+                cache.guidanceByName[definition.name] = PlanDayEditorCache.ExerciseGuidance(
+                    repsText: definition.repsText,
+                    setsText: definition.setsText,
+                    restText: definition.restText,
+                    notes: definition.notes,
+                    durationText: definition.durationText
+                )
+            }
+        }
+
         // 4) Logged items
         refreshLoggedItemsIntoCache()
     }
@@ -1654,11 +1770,14 @@ struct PlanDayEditor: View {
         let _ = calendar.date(byAdding: .day, value: 1, to: dayStart)!
         
         let p = cache.parentPlan
+        let planExerciseID = p?.exerciseDefinitions.first { $0.name == exerciseName }?.id
         
         session.items.append(SessionItem(
             exerciseName: exerciseName,
             planSourceId: p?.id,
             planName: p?.name,
+            planDayId: day.id,
+            planExerciseID: planExerciseID,
             reps: reps,
             sets: sets,
             weightKg: weight,
@@ -1676,12 +1795,15 @@ struct PlanDayEditor: View {
         let session = findOrCreateSession(for: day.date, in: context)
         
         let p = cache.parentPlan
+        let planExerciseID = p?.exerciseDefinitions.first { $0.name == name }?.id
         
         // Create a simple log entry without metrics - just capture that it was done
         session.items.append(SessionItem(
             exerciseName: name,
             planSourceId: p?.id,
             planName: p?.name,
+            planDayId: day.id,
+            planExerciseID: planExerciseID,
             reps: nil,
             sets: nil,
             weightKg: nil,
@@ -1855,12 +1977,17 @@ private struct PlanClimbLogView: View {
         let p = parentPlan
         let session = findOrCreateSession(for: planDay.date, in: context)
 
+        climbEntry.planSourceId = p?.id
+        climbEntry.planDayId = planDay.id
+
         let attemptsDouble = climbEntry.attempts != nil ? Double(climbEntry.attempts!) : nil
 
         session.items.append(SessionItem(
             exerciseName: exerciseName,
             planSourceId: p?.id,
             planName: p?.name,
+            planDayId: planDay.id,
+            climbEntryId: climbEntry.id,
             reps: attemptsDouble,
             sets: nil,
             weightKg: nil,

--- a/ClimbingProgram/features/plans/PlansViews.swift
+++ b/ClimbingProgram/features/plans/PlansViews.swift
@@ -120,10 +120,7 @@ struct PlansListView: View {
 
     @State private var sheetRoute: SheetRoute?
 
-    // Export / Import / Share state
-    @State private var showExporter = false
-    @State private var exportDoc: LogCSVDocument? = nil
-
+    // Plan export / import state
     @State private var showPlanExporter = false
     @State private var planExportDoc: PlanCSVDocument? = nil
     @State private var planExportFilename = "klettrack_plan"
@@ -131,14 +128,6 @@ struct PlansListView: View {
     @State private var planImportTarget: Plan? = nil
     @State private var pendingPlanImport: PendingPlanImport? = nil
     @State private var planImportSummary: PlanCSVExchange.Summary? = nil
-
-    // Import (async with progress)
-    @State private var showImporter = false
-    @State private var importing = false
-    @State private var importProgress: Double = 0
-
-    // Share (use Identifiable payload)
-    @State private var sharePayload: SharePayload? = nil
 
     // Alerts
     @State private var resultMessage: String? = nil
@@ -166,7 +155,6 @@ struct PlansListView: View {
                 )
                 .plansToolbar(
                     isDataReady: isDataReady,
-                    context: context,
                     showingNew: Binding(
                         get: { sheetRoute == .newPlan },
                         set: { newValue in
@@ -177,30 +165,13 @@ struct PlansListView: View {
                             }
                         }
                     ),
-                    showExporter: $showExporter,
-                    exportDoc: $exportDoc,
-                    showImporter: $showImporter,
                     showPlanImporter: $showPlanImporter,
-                    sharePayload: $sharePayload,
-                    resultMessage: $resultMessage
+                    planImportTarget: $planImportTarget
                 )
                 .sheet(item: $sheetRoute) { route in
                     switch route {
                     case .newPlan:
                         NewPlanSheet()
-                    }
-                }
-                .fileExporter(
-                    isPresented: $showExporter,
-                    document: exportDoc,
-                    contentType: .commaSeparatedText,
-                    defaultFilename: "klettrack-log-\(Date().formatted(.dateTime.year().month().day()))"
-                ) { result in
-                    switch result {
-                    case .success:
-                        resultMessage = "CSV exported."
-                    case .failure(let err):
-                        resultMessage = "Export failed: \(err.localizedDescription)"
                     }
                 }
                 .fileExporter(
@@ -215,13 +186,6 @@ struct PlansListView: View {
                     case .failure(let error):
                         resultMessage = "Plan export failed: \(error.localizedDescription)"
                     }
-                }
-                .fileImporter(
-                    isPresented: $showImporter,
-                    allowedContentTypes: [.commaSeparatedText],
-                    allowsMultipleSelection: false
-                ) { result in
-                    handleImportResult(result)
                 }
                 .fileImporter(
                     isPresented: $showPlanImporter,
@@ -242,12 +206,6 @@ struct PlansListView: View {
                 }
                 .sheet(item: $planImportSummary) { summary in
                     PlanImportSummarySheet(summary: summary)
-                }
-                .sheet(item: $sharePayload) { payload in
-                    ShareSheet(items: [payload.url]) {
-                        try? FileManager.default.removeItem(at: payload.url)
-                    }
-                    .presentationDetents([.medium])
                 }
                 .alert(resultMessage ?? "", isPresented: Binding(
                     get: { resultMessage != nil },
@@ -316,44 +274,6 @@ struct PlansListView: View {
     }
 
     
-    private func handleImportResult(_ result: Result<[URL], Error>) {
-        do {
-            guard let url = try result.get().first else { return }
-            let df = ISO8601DateFormatter(); df.formatOptions = [.withFullDate]
-            let tag = "import:\(df.string(from: Date()))"
-
-            importing = true
-            importProgress = 0
-
-            Task {
-                do {
-                    let count = try await LogCSV.importCSVAsync(
-                        from: url,
-                        into: context,
-                        tag: tag,
-                        dedupe: true,
-                        progress: { p in
-                            Task { @MainActor in
-                                importProgress = p
-                            }
-                        }
-                    )
-                    await MainActor.run {
-                        importing = false
-                        resultMessage = "Imported \(count) log item(s)."
-                    }
-                } catch {
-                    await MainActor.run {
-                        importing = false
-                        resultMessage = "Import failed: \(error.localizedDescription)"
-                    }
-                }
-            }
-        } catch {
-            resultMessage = "Import failed: \(error.localizedDescription)"
-        }
-    }
-
     private func handlePlanImportResult(_ result: Result<[URL], Error>) {
         do {
             guard let url = try result.get().first else { return }
@@ -435,15 +355,10 @@ private extension View {
 
 private struct PlansToolbarModifier: ViewModifier {
     let isDataReady: Bool
-    let context: ModelContext
 
     @Binding var showingNew: Bool
-    @Binding var showExporter: Bool
-    @Binding var exportDoc: LogCSVDocument?
-    @Binding var showImporter: Bool
     @Binding var showPlanImporter: Bool
-    @Binding var sharePayload: SharePayload?
-    @Binding var resultMessage: String?
+    @Binding var planImportTarget: Plan?
 
     func body(content: Content) -> some View {
         content.toolbar {
@@ -451,57 +366,21 @@ private struct PlansToolbarModifier: ViewModifier {
                 Menu {
                     Button {
                         guard isDataReady else { return }
-                        exportDoc = LogCSV.makeExportCSV(context: context)
-                        showExporter = true
+                        showingNew = true
                     } label: {
-                        Label("Export Logs", systemImage: "square.and.arrow.up")
+                        Label("New Plan", systemImage: "plus")
                     }
 
                     Button {
                         guard isDataReady else { return }
-                        let doc = LogCSV.makeExportCSV(context: context)
-                        let fn = "klettrack-log-\(Date().formatted(.dateTime.year().month().day())).csv"
-                        let url = FileManager.default.temporaryDirectory.appendingPathComponent(fn)
-
-                        do {
-                            try doc.csv.write(to: url, atomically: true, encoding: .utf8)
-                            guard FileManager.default.fileExists(atPath: url.path) else {
-                                resultMessage = "Share failed: file not found."
-                                return
-                            }
-                            sharePayload = SharePayload(url: url)
-                        } catch {
-                            resultMessage = "Share prep failed: \(error.localizedDescription)"
-                        }
-                    } label: {
-                        Label("Share Logs", systemImage: "square.and.arrow.up.on.square")
-                    }
-
-                    Button {
-                        guard isDataReady else { return }
-                        showImporter = true
-                    } label: {
-                        Label("Import Logs", systemImage: "square.and.arrow.down")
-                    }
-
-                    Button {
-                        guard isDataReady else { return }
+                        planImportTarget = nil
                         showPlanImporter = true
                     } label: {
-                        Label("Import New Plan", systemImage: "arrow.down.document")
+                        Label("Import Plan", systemImage: "arrow.down.document")
                     }
                 } label: {
-                    Image(systemName: "ellipsis.circle")
-                }
-                .disabled(!isDataReady)
-            }
-
-            ToolbarItem(placement: .topBarTrailing) {
-                Button {
-                    guard isDataReady else { return }
-                    showingNew = true
-                } label: {
                     Image(systemName: "plus")
+                        .accessibilityLabel("Create or import plan")
                 }
                 .disabled(!isDataReady)
             }
@@ -512,25 +391,15 @@ private struct PlansToolbarModifier: ViewModifier {
 private extension View {
     func plansToolbar(
         isDataReady: Bool,
-        context: ModelContext,
         showingNew: Binding<Bool>,
-        showExporter: Binding<Bool>,
-        exportDoc: Binding<LogCSVDocument?>,
-        showImporter: Binding<Bool>,
         showPlanImporter: Binding<Bool>,
-        sharePayload: Binding<SharePayload?>,
-        resultMessage: Binding<String?>
+        planImportTarget: Binding<Plan?>
     ) -> some View {
         modifier(PlansToolbarModifier(
             isDataReady: isDataReady,
-            context: context,
             showingNew: showingNew,
-            showExporter: showExporter,
-            exportDoc: exportDoc,
-            showImporter: showImporter,
             showPlanImporter: showPlanImporter,
-            sharePayload: sharePayload,
-            resultMessage: resultMessage
+            planImportTarget: planImportTarget
         ))
     }
 }

--- a/ClimbingProgram/features/plans/PlansViews.swift
+++ b/ClimbingProgram/features/plans/PlansViews.swift
@@ -126,6 +126,7 @@ struct PlansListView: View {
 
     @State private var showPlanExporter = false
     @State private var planExportDoc: PlanCSVDocument? = nil
+    @State private var planExportFilename = "klettrack_plan"
     @State private var showPlanImporter = false
     @State private var planImportTarget: Plan? = nil
     @State private var pendingPlanImport: PendingPlanImport? = nil
@@ -205,7 +206,7 @@ struct PlansListView: View {
                     isPresented: $showPlanExporter,
                     document: planExportDoc,
                     contentType: .commaSeparatedText,
-                    defaultFilename: "klettrack-plan-\(Date().formatted(.dateTime.year().month().day()))"
+                    defaultFilename: planExportFilename
                 ) { result in
                     switch result {
                     case .success:
@@ -267,6 +268,7 @@ struct PlansListView: View {
 
                     Menu {
                         Button {
+                            planExportFilename = PlanCSVExchange.exportFilename(for: plan)
                             planExportDoc = PlanCSVExchange.export(plan: plan, in: context)
                             showPlanExporter = true
                         } label: {
@@ -286,6 +288,7 @@ struct PlansListView: View {
                 }
                 .contextMenu {
                     Button {
+                        planExportFilename = PlanCSVExchange.exportFilename(for: plan)
                         planExportDoc = PlanCSVExchange.export(plan: plan, in: context)
                         showPlanExporter = true
                     } label: {

--- a/ClimbingProgram/features/plans/PlansViews.swift
+++ b/ClimbingProgram/features/plans/PlansViews.swift
@@ -130,6 +130,7 @@ struct PlansListView: View {
     @State private var showPlanImporter = false
     @State private var planImportTarget: Plan? = nil
     @State private var pendingPlanImport: PendingPlanImport? = nil
+    @State private var planImportSummary: PlanCSVExchange.Summary? = nil
 
     // Import (async with progress)
     @State private var showImporter = false
@@ -233,11 +234,14 @@ struct PlansListView: View {
                     PlanImportPreviewSheet(pending: pending) { result in
                         switch result {
                         case .success(let summary):
-                            resultMessage = summary.message
+                            planImportSummary = summary
                         case .failure(let error):
                             resultMessage = "Plan import failed: \(error.localizedDescription)"
                         }
                     }
+                }
+                .sheet(item: $planImportSummary) { summary in
+                    PlanImportSummarySheet(summary: summary)
                 }
                 .sheet(item: $sharePayload) { payload in
                     ShareSheet(items: [payload.url]) {

--- a/ClimbingProgram/features/sessions/LogView.swift
+++ b/ClimbingProgram/features/sessions/LogView.swift
@@ -207,19 +207,19 @@ struct LogView: View {
             exportDoc = LogCSV.makeExportCSV(context: context)
             modalRoute = .exportCSV
         } label: {
-            Label("Export logs to CSV", systemImage: "square.and.arrow.up")
+            Label("Export Logs", systemImage: "square.and.arrow.up")
         }
     }
 
     private var shareButton: some View {
         Button { prepareShare() } label: {
-            Label("Share logs (CSV)…", systemImage: "square.and.arrow.up.on.square")
+            Label("Share Logs", systemImage: "square.and.arrow.up.on.square")
         }
     }
 
     private var importButton: some View {
         Button { modalRoute = .importCSV } label: {
-            Label("Import logs from CSV", systemImage: "square.and.arrow.down")
+            Label("Import Logs", systemImage: "square.and.arrow.down")
         }
     }
 

--- a/ClimbingProgram/shared/ClimbEntrySnapshotter.swift
+++ b/ClimbingProgram/shared/ClimbEntrySnapshotter.swift
@@ -39,6 +39,8 @@ struct ClimbEntrySnapshotter: UndoSnapshotting {
             gym: c.gym,
             notes: c.notes,
             dateLogged: c.dateLogged,
+            planSourceId: c.planSourceId,
+            planDayId: c.planDayId,
             tb2ClimbUUID: c.tb2ClimbUUID,
             kilterLogUuid: c.kilterLogUuid,
             kilterClimbUuid: c.kilterClimbUuid,
@@ -66,6 +68,8 @@ struct ClimbEntrySnapshotter: UndoSnapshotting {
             gym: s.gym,
             notes: s.notes,
             dateLogged: s.dateLogged,
+            planSourceId: s.planSourceId,
+            planDayId: s.planDayId,
             tb2ClimbUUID: s.tb2ClimbUUID,
             kilterLogUuid: s.kilterLogUuid,
             kilterClimbUuid: s.kilterClimbUuid
@@ -108,6 +112,8 @@ struct ClimbEntrySnapshotter: UndoSnapshotting {
         let gym: String
         let notes: String?
         let dateLogged: Date
+        let planSourceId: UUID?
+        let planDayId: UUID?
         let tb2ClimbUUID: String?
         let kilterLogUuid: String?
         let kilterClimbUuid: String?

--- a/ClimbingProgram/shared/DayContextViews.swift
+++ b/ClimbingProgram/shared/DayContextViews.swift
@@ -114,7 +114,7 @@ struct DayContextEditorSection: View {
     var body: some View {
         Section("Day Context") {
             TextEditor(text: $noteText)
-                .frame(height: 120)
+                .frame(height: 90)
                 .scrollIndicators(.visible, axes: .vertical)
                 .scrollDismissesKeyboard(.interactively)
                 .focused(focusedField, equals: .note)
@@ -218,10 +218,9 @@ struct DayContextEditorSection: View {
     }
 
     private func saveNote() {
-        let trimmed = noteText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty || dayLog != nil else { return }
+        guard !noteText.isEmpty || dayLog != nil else { return }
         guard let editable = editableDayLog() else { return }
-        if editable.note != trimmed {
+        if editable.note != noteText {
             DayLogStore.setNote(noteText, for: editable)
             try? context.save()
             onDayLogChanged(editable)

--- a/ClimbingProgram/shared/DayContextViews.swift
+++ b/ClimbingProgram/shared/DayContextViews.swift
@@ -128,8 +128,14 @@ struct DayContextEditorSection: View {
                             .allowsHitTesting(false)
                     }
                 }
-                .onChange(of: noteText) { _, _ in
-                    saveNote()
+                .task(id: noteText) {
+                    guard noteText != (dayLog?.note ?? "") else { return }
+                    do {
+                        try await Task.sleep(for: .milliseconds(350))
+                        saveNote()
+                    } catch {
+                        // The task is cancelled when another keystroke arrives.
+                    }
                 }
 
             VStack(alignment: .leading, spacing: 10) {
@@ -171,6 +177,7 @@ struct DayContextEditorSection: View {
         }
         .onDisappear {
             focusedField.wrappedValue = nil
+            saveNote()
         }
         .alert(errorMessage ?? "", isPresented: Binding(
             get: { errorMessage != nil },

--- a/ClimbingProgramTests/CatalogPersistenceTests.swift
+++ b/ClimbingProgramTests/CatalogPersistenceTests.swift
@@ -37,7 +37,7 @@ final class CatalogPersistenceTests: BaseSwiftDataTestCase {
     }
 
     func testEditingExercisePersistsDurationWhenSetsAreEmpty() throws {
-        let exercise = Exercise(name: "Existing", setsText: "3", durationText: "10 sec")
+        let exercise = Exercise(name: "Existing", durationText: "10 sec", setsText: "3")
         context.insert(exercise)
         try context.save()
 
@@ -54,10 +54,11 @@ final class CatalogPersistenceTests: BaseSwiftDataTestCase {
         draft.apply(to: exercise)
         try CatalogExercisePersistence.saveExisting(exercise, in: context)
 
+        let exerciseID = exercise.id
         let descriptor = FetchDescriptor<Exercise>(
-            predicate: #Predicate { $0.id == exercise.id }
+            predicate: #Predicate { $0.id == exerciseID }
         )
-        let reloaded = try XCTUnwrap(try context.fetch(descriptor).first)
+        let reloaded: Exercise = try XCTUnwrap(try context.fetch(descriptor).first)
         XCTAssertNil(reloaded.setsText)
         XCTAssertEqual(reloaded.durationText, "60 sec")
         XCTAssertEqual(reloaded.restText, "90 sec")

--- a/ClimbingProgramTests/ClimbingProgramTestSuite.swift
+++ b/ClimbingProgramTests/ClimbingProgramTestSuite.swift
@@ -24,7 +24,7 @@ class ClimbingProgramTestSuite: XCTestCase {
             Exercise.self,
 
             // Plans
-            Plan.self,
+            Plan.self, PlanKindModel.self, DayTypeModel.self, PlanExerciseDefinition.self,
             PlanDay.self,
 
             // Sessions (log)

--- a/ClimbingProgramTests/DayLogStoreTests.swift
+++ b/ClimbingProgramTests/DayLogStoreTests.swift
@@ -16,13 +16,16 @@ final class DayLogStoreTests: BaseSwiftDataTestCase {
         XCTAssertEqual(first.date, calendar.startOfDay(for: morning))
     }
 
-    func testSetNoteTrimsEmptyValuesToNil() throws {
+    func testSetNotePreservesWhitespaceAndTreatsOnlyEmptyStringAsNil() throws {
         let dayLog = try XCTUnwrap(DayLogStore.dayLog(for: Date(), in: context))
 
         DayLogStore.setNote("  Good session  ", for: dayLog)
-        XCTAssertEqual(dayLog.note, "Good session")
+        XCTAssertEqual(dayLog.note, "  Good session  ")
 
         DayLogStore.setNote("   \n ", for: dayLog)
+        XCTAssertEqual(dayLog.note, "   \n ")
+
+        DayLogStore.setNote("", for: dayLog)
         XCTAssertNil(dayLog.note)
     }
 

--- a/ClimbingProgramTests/PlanCSVExchangeTests.swift
+++ b/ClimbingProgramTests/PlanCSVExchangeTests.swift
@@ -47,12 +47,13 @@ final class PlanCSVExchangeTests: XCTestCase {
         XCTAssertEqual(parsed.exercises.first?.name, "Imported Drill")
     }
 
-    func testParseAcceptsUTF8ByteOrderMarkBeforeHeader() throws {
+    func testParseAcceptsUTF8ByteOrderMarkAndCRLFLineEndings() throws {
         let plan = Plan(name: "BOM Plan", kind: nil, startDate: Date())
         context.insert(plan)
         try context.save()
 
         let csv = "\u{FEFF}" + PlanCSVExchange.export(plan: plan, in: context).csv
+            .replacingOccurrences(of: "\n", with: "\r\n")
         let parsed = try PlanCSVExchange.parse(csv)
 
         XCTAssertEqual(parsed.plan.name, "BOM Plan")

--- a/ClimbingProgramTests/PlanCSVExchangeTests.swift
+++ b/ClimbingProgramTests/PlanCSVExchangeTests.swift
@@ -1,0 +1,324 @@
+import XCTest
+import SwiftData
+@testable import klettrack
+
+@MainActor
+final class PlanCSVExchangeTests: XCTestCase {
+    private var container: ModelContainer!
+    private var context: ModelContext { container.mainContext }
+
+    override func setUpWithError() throws {
+        let schema = Schema([
+            Activity.self, TrainingType.self, BoulderCombination.self, Exercise.self,
+            Plan.self, PlanDay.self, PlanKindModel.self, DayTypeModel.self, PlanExerciseDefinition.self,
+            Session.self, SessionItem.self, DayLog.self, DayTag.self,
+            ClimbEntry.self, ClimbStyle.self, ClimbGym.self, ClimbMedia.self,
+            TB2ClimbMetadata.self, TB2ClimbStatsMetadata.self
+        ])
+        container = try ModelContainer(for: schema, configurations: ModelConfiguration(isStoredInMemoryOnly: true))
+    }
+
+    override func tearDownWithError() throws {
+        container = nil
+    }
+
+    func testExportRoundTripIncludesEmptyDaysAndPlanFields() throws {
+        let kind = PlanKindModel(key: "weekly", name: "Weekly", isRepeating: true)
+        let type = DayTypeModel(key: "strength", name: "Strength", colorKey: "purple")
+        context.insert(kind)
+        context.insert(type)
+
+        let plan = Plan(name: "Exchange Plan", kind: kind, startDate: Date(timeIntervalSince1970: 1_700_000_000))
+        let firstDay = PlanDay(date: plan.startDate, type: type)
+        firstDay.dailyNotes = "Keep quality high"
+        firstDay.chosenExercises = ["Imported Drill"]
+        let emptyDay = PlanDay(date: Calendar.current.date(byAdding: .day, value: 1, to: plan.startDate) ?? plan.startDate, type: type)
+        plan.days = [firstDay, emptyDay]
+        context.insert(plan)
+        try context.save()
+
+        let csv = PlanCSVExchange.export(plan: plan, in: context).csv
+        let parsed = try PlanCSVExchange.parse(csv)
+
+        XCTAssertTrue(csv.contains("row_type"))
+        XCTAssertEqual(parsed.plan.name, "Exchange Plan")
+        XCTAssertEqual(parsed.days.count, 2)
+        XCTAssertEqual(parsed.exercises.count, 1)
+        XCTAssertEqual(parsed.exercises.first?.name, "Imported Drill")
+    }
+
+    func testImportNewPlanBackfillsMissingExerciseUnderImportedCatalog() throws {
+        let source = Plan(name: "Imported Plan", kind: nil, startDate: Date())
+        let day = PlanDay(date: source.startDate)
+        day.chosenExercises = ["New Outside Exercise"]
+        source.days = [day]
+        context.insert(source)
+        try context.save()
+
+        let parsed = try PlanCSVExchange.parse(PlanCSVExchange.export(plan: source, in: context).csv)
+        let summary = try PlanCSVExchange.apply(parsed, mode: .newPlan, in: context)
+
+        XCTAssertEqual(summary.planName, "Imported Plan")
+        let activities = try context.fetch(FetchDescriptor<Activity>())
+        let imported = try XCTUnwrap(activities.first { $0.name == "Imported" })
+        let importedType = try XCTUnwrap(imported.types.first { $0.name == "Imported Plans" })
+        XCTAssertEqual(importedType.exercises.map(\.name), ["New Outside Exercise"])
+        XCTAssertEqual(try context.fetch(FetchDescriptor<Plan>()).count, 2)
+    }
+
+    func testExistingImportPreservesLoggedItemAndRemovesUnloggedDay() throws {
+        let plan = Plan(name: "Existing", kind: nil, startDate: Date())
+        let loggedDay = PlanDay(date: plan.startDate)
+        loggedDay.chosenExercises = ["Logged Exercise"]
+        let unloggedDay = PlanDay(date: Calendar.current.date(byAdding: .day, value: 1, to: plan.startDate) ?? plan.startDate)
+        unloggedDay.chosenExercises = ["Remove Me"]
+        plan.days = [loggedDay, unloggedDay]
+        context.insert(plan)
+
+        let session = Session(date: plan.startDate)
+        let item = SessionItem(exerciseName: "Logged Exercise", planSourceId: plan.id, planName: plan.name, planDayId: loggedDay.id, reps: 5, notes: "Original")
+        session.items = [item]
+        context.insert(session)
+        try context.save()
+
+        var edited = try PlanCSVExchange.parse(PlanCSVExchange.export(plan: plan, in: context).csv)
+        edited.days.removeAll { Calendar.current.isDate($0.date, inSameDayAs: unloggedDay.date) }
+        edited.plan.name = "Edited Existing"
+
+        _ = try PlanCSVExchange.apply(edited, mode: .existing(plan), in: context)
+
+        XCTAssertEqual(item.reps, 5)
+        XCTAssertEqual(item.notes, "Original")
+        XCTAssertTrue(plan.days.contains { $0.id == loggedDay.id })
+        XCTAssertFalse(plan.days.contains { $0.id == unloggedDay.id })
+        XCTAssertEqual(plan.name, "Edited Existing")
+    }
+
+    func testRepeatedImportDoesNotDuplicateLogs() throws {
+        let source = Plan(name: "Repeatable", kind: nil, startDate: Date())
+        let day = PlanDay(date: source.startDate)
+        day.chosenExercises = ["Exercise"]
+        source.days = [day]
+        context.insert(source)
+        let session = Session(date: source.startDate)
+        session.items = [SessionItem(exerciseName: "Exercise", planSourceId: source.id, planName: source.name, planDayId: day.id)]
+        context.insert(session)
+        try context.save()
+
+        let parsed = try PlanCSVExchange.parse(PlanCSVExchange.export(plan: source, in: context).csv)
+        let first = try PlanCSVExchange.apply(parsed, mode: .existing(source), in: context)
+        let second = try PlanCSVExchange.apply(parsed, mode: .existing(source), in: context)
+
+        XCTAssertEqual(first.logCount, 0)
+        XCTAssertEqual(second.logCount, 0)
+        XCTAssertEqual(session.items.count, 1)
+    }
+
+    func testImportedExerciseMovePreservesIdentity() throws {
+        let importedActivity = Activity(name: "Imported")
+        let importedType = TrainingType(name: "Imported Plans")
+        let exercise = Exercise(name: "Move Me")
+        importedType.exercises.append(exercise)
+        importedActivity.types.append(importedType)
+
+        let destinationActivity = Activity(name: "Strength")
+        let destinationType = TrainingType(name: "Pull")
+        destinationActivity.types.append(destinationType)
+        context.insert(importedActivity)
+        context.insert(destinationActivity)
+        context.insert(exercise)
+        try context.save()
+
+        let destination = try XCTUnwrap(CatalogReassignment.destinations(in: context).first { $0.type.id == destinationType.id })
+        let originalID = exercise.id
+        try CatalogReassignment.move(exercise, from: importedType, sourceCombination: nil, to: destination, in: context)
+
+        XCTAssertEqual(exercise.id, originalID)
+        XCTAssertFalse(importedType.exercises.contains { $0.id == originalID })
+        XCTAssertTrue(destinationType.exercises.contains { $0.id == originalID })
+        XCTAssertNil(try context.fetch(FetchDescriptor<Activity>()).first { $0.id == importedActivity.id })
+        XCTAssertNil(try context.fetch(FetchDescriptor<TrainingType>()).first { $0.id == importedType.id })
+    }
+
+    func testNonEmptyNodeRequiresConfirmationBeforeDeletion() throws {
+        let activity = Activity(name: "Imported")
+        let type = TrainingType(name: "Imported Plans")
+        let exercise = Exercise(name: "Keep Until Confirmed")
+        type.exercises.append(exercise)
+        activity.types.append(type)
+        context.insert(activity)
+        context.insert(type)
+        context.insert(exercise)
+        try context.save()
+
+        let request = CatalogDeletion.request(for: .activity(activity), in: context)
+        XCTAssertFalse(request.impact.isEmpty)
+        XCTAssertEqual(type.exercises.count, 1)
+
+        try CatalogDeletion.delete(request, in: context)
+
+        XCTAssertNil(try context.fetch(FetchDescriptor<Activity>()).first { $0.id == activity.id })
+        XCTAssertNil(try context.fetch(FetchDescriptor<Exercise>()).first { $0.id == exercise.id })
+    }
+
+    func testBulkMovePreservesAllExerciseIdentitiesAndCleansImportedContainers() throws {
+        let importedActivity = Activity(name: "Imported")
+        let importedType = TrainingType(name: "Imported Plans")
+        let firstExercise = Exercise(name: "Bulk One")
+        let secondExercise = Exercise(name: "Bulk Two")
+        importedType.exercises = [firstExercise, secondExercise]
+        importedActivity.types.append(importedType)
+
+        let destinationActivity = Activity(name: "Core")
+        let destinationType = TrainingType(name: "Anterior Core")
+        destinationActivity.types.append(destinationType)
+        context.insert(importedActivity)
+        context.insert(importedType)
+        context.insert(firstExercise)
+        context.insert(secondExercise)
+        context.insert(destinationActivity)
+        context.insert(destinationType)
+        try context.save()
+
+        let destination = try XCTUnwrap(CatalogReassignment.destinations(in: context).first { $0.type.id == destinationType.id })
+        let originalIDs = Set([firstExercise.id, secondExercise.id])
+        try CatalogReassignment.move(
+            [firstExercise, secondExercise],
+            from: importedType,
+            sourceCombination: nil,
+            to: destination,
+            in: context
+        )
+
+        XCTAssertEqual(Set(destinationType.exercises.map(\.id)), originalIDs)
+        XCTAssertTrue(importedType.exercises.isEmpty)
+        XCTAssertNil(try context.fetch(FetchDescriptor<Activity>()).first { $0.id == importedActivity.id })
+    }
+
+    func testEmptyCatalogNodesDeleteWithoutChildData() throws {
+        let emptyActivity = Activity(name: "Empty Activity")
+        let typeActivity = Activity(name: "Type Activity")
+        let emptyType = TrainingType(name: "Empty Type")
+        typeActivity.types.append(emptyType)
+
+        let combinationActivity = Activity(name: "Combination Activity")
+        let combinationType = TrainingType(name: "Combination Type")
+        let emptyCombination = BoulderCombination(name: "Empty Combination")
+        combinationType.combinations.append(emptyCombination)
+        combinationActivity.types.append(combinationType)
+
+        context.insert(emptyActivity)
+        context.insert(typeActivity)
+        context.insert(emptyType)
+        context.insert(combinationActivity)
+        context.insert(combinationType)
+        context.insert(emptyCombination)
+        try context.save()
+
+        XCTAssertTrue(CatalogDeletion.request(for: .activity(emptyActivity), in: context).impact.isEmpty)
+        XCTAssertTrue(CatalogDeletion.request(for: .trainingType(emptyType), in: context).impact.isEmpty)
+        XCTAssertTrue(CatalogDeletion.request(for: .combination(emptyCombination), in: context).impact.isEmpty)
+
+        try CatalogDeletion.delete(.activity(emptyActivity), in: context)
+        try CatalogDeletion.delete(.trainingType(emptyType), in: context)
+        try CatalogDeletion.delete(.combination(emptyCombination), in: context)
+
+        XCTAssertNil(try context.fetch(FetchDescriptor<Activity>()).first { $0.id == emptyActivity.id })
+        XCTAssertNil(try context.fetch(FetchDescriptor<TrainingType>()).first { $0.id == emptyType.id })
+        XCTAssertNil(try context.fetch(FetchDescriptor<BoulderCombination>()).first { $0.id == emptyCombination.id })
+        XCTAssertNotNil(try context.fetch(FetchDescriptor<Activity>()).first { $0.id == combinationActivity.id })
+    }
+
+    func testDeletingTrainingTypePreservesExerciseSharedByAnotherNode() throws {
+        let activity = Activity(name: "Shared Activity")
+        let firstType = TrainingType(name: "First")
+        let secondType = TrainingType(name: "Second")
+        let sharedExercise = Exercise(name: "Shared Exercise")
+        firstType.exercises.append(sharedExercise)
+        secondType.exercises.append(sharedExercise)
+        activity.types = [firstType, secondType]
+        context.insert(activity)
+        context.insert(firstType)
+        context.insert(secondType)
+        context.insert(sharedExercise)
+        try context.save()
+
+        try CatalogDeletion.delete(.trainingType(firstType), in: context)
+
+        XCTAssertTrue(secondType.exercises.contains { $0.id == sharedExercise.id })
+        XCTAssertNotNil(try context.fetch(FetchDescriptor<Exercise>()).first { $0.id == sharedExercise.id })
+        XCTAssertNil(try context.fetch(FetchDescriptor<TrainingType>()).first { $0.id == firstType.id })
+    }
+
+    func testFinalCatalogPlacementClearsPlanLinkButPreservesPlanAndLogs() throws {
+        let activity = Activity(name: "Catalog Activity")
+        let type = TrainingType(name: "Catalog Type")
+        let exercise = Exercise(name: "Plan Exercise")
+        type.exercises.append(exercise)
+        activity.types.append(type)
+        context.insert(activity)
+        context.insert(type)
+        context.insert(exercise)
+
+        let plan = Plan(name: "Preserved Plan", kind: nil, startDate: Date())
+        let day = PlanDay(date: plan.startDate)
+        let definition = PlanExerciseDefinition(catalogExerciseID: exercise.id, name: exercise.name, repsText: "5", notes: "Keep guidance")
+        day.chosenExercises = [exercise.name]
+        day.chosenExerciseIDs = [exercise.id]
+        day.planExerciseIDs = [definition.id]
+        day.exerciseOrderByID = [exercise.id.uuidString: 0]
+        day.exerciseOrder = [exercise.name: 0]
+        plan.days = [day]
+        plan.exerciseDefinitions = [definition]
+        context.insert(plan)
+        context.insert(day)
+        context.insert(definition)
+
+        let session = Session(date: plan.startDate)
+        let item = SessionItem(exerciseName: exercise.name, planSourceId: plan.id, planDayId: day.id, planExerciseID: definition.id, reps: 5, notes: "Logged")
+        session.items = [item]
+        context.insert(session)
+
+        let climb = ClimbEntry(climbType: .boulder, grade: "V3", style: "Flash", gym: "Test Gym", dateLogged: plan.startDate, planSourceId: plan.id, planDayId: day.id)
+        context.insert(climb)
+        try context.save()
+
+        try CatalogDeletion.delete(.trainingType(type), in: context)
+
+        XCTAssertEqual(plan.name, "Preserved Plan")
+        XCTAssertEqual(day.chosenExercises, [exercise.name])
+        XCTAssertEqual(day.planExerciseIDs, [definition.id])
+        XCTAssertEqual(day.exerciseOrder, [exercise.name: 0])
+        XCTAssertTrue(day.chosenExerciseIDs.isEmpty)
+        XCTAssertTrue(day.exerciseOrderByID.isEmpty)
+        XCTAssertNil(definition.catalogExerciseID)
+        XCTAssertEqual(item.notes, "Logged")
+        XCTAssertEqual(climb.grade, "V3")
+        XCTAssertNil(try context.fetch(FetchDescriptor<Exercise>()).first { $0.id == exercise.id })
+    }
+
+    func testDeletingActivityRecursivelyRemovesTypesCombinationsAndExercises() throws {
+        let activity = Activity(name: "Recursive Activity")
+        let type = TrainingType(name: "Recursive Type")
+        let combination = BoulderCombination(name: "Recursive Combination")
+        let directExercise = Exercise(name: "Direct")
+        let combinationExercise = Exercise(name: "Combination")
+        type.exercises.append(directExercise)
+        combination.exercises.append(combinationExercise)
+        type.combinations.append(combination)
+        activity.types.append(type)
+        context.insert(activity)
+        context.insert(type)
+        context.insert(combination)
+        context.insert(directExercise)
+        context.insert(combinationExercise)
+        try context.save()
+
+        try CatalogDeletion.delete(.activity(activity), in: context)
+
+        XCTAssertNil(try context.fetch(FetchDescriptor<Activity>()).first { $0.id == activity.id })
+        XCTAssertNil(try context.fetch(FetchDescriptor<TrainingType>()).first { $0.id == type.id })
+        XCTAssertNil(try context.fetch(FetchDescriptor<BoulderCombination>()).first { $0.id == combination.id })
+        XCTAssertTrue(try context.fetch(FetchDescriptor<Exercise>()).isEmpty)
+    }
+}

--- a/ClimbingProgramTests/PlanCSVExchangeTests.swift
+++ b/ClimbingProgramTests/PlanCSVExchangeTests.swift
@@ -197,6 +197,44 @@ final class PlanCSVExchangeTests: XCTestCase {
         XCTAssertEqual(DayLogStore.activeTags(from: dayLog).map(\.name), ["CSV"])
     }
 
+    func testImportPreviewReportsProtectedRecordsAndActualChanges() throws {
+        let plan = Plan(name: "Existing", kind: nil, startDate: Date())
+        let day = PlanDay(date: plan.startDate)
+        day.chosenExercises = ["Logged Exercise", "Remove Me"]
+        plan.days = [day]
+        context.insert(plan)
+
+        let session = Session(date: plan.startDate)
+        let loggedItem = SessionItem(
+            exerciseName: "Logged Exercise",
+            planSourceId: plan.id,
+            planName: plan.name,
+            planDayId: day.id
+        )
+        session.items = [loggedItem]
+        context.insert(session)
+        try context.save()
+
+        var edited = try PlanCSVExchange.parse(PlanCSVExchange.export(plan: plan, in: context).csv)
+        let loggedID = try XCTUnwrap(edited.exercises.first { $0.name == "Logged Exercise" }?.id)
+        let newID = UUID()
+        edited.plan.name = "Updated"
+        edited.exercises.append(.init(id: newID, catalogID: nil, name: "New Exercise", area: nil, description: nil, reps: nil, sets: nil, duration: nil, rest: nil, notes: nil))
+        edited.days[0].exerciseRefs = [(newID, 0), (loggedID, 1)]
+        edited.contexts = [.init(date: plan.startDate, note: "CSV context", tags: [])]
+
+        let preview = PlanCSVExchange.preview(edited, mode: .existing(plan), overwriteDayContext: true, in: context)
+
+        XCTAssertEqual(preview.metadataChanges, ["Plan name"])
+        XCTAssertEqual(preview.daysToUpdate, 1)
+        XCTAssertEqual(preview.scheduleEntriesToAdd, 1)
+        XCTAssertEqual(preview.scheduleEntriesToRemove, 1)
+        XCTAssertEqual(preview.protectedLoggedExerciseCount, 1)
+        XCTAssertEqual(preview.existingLogCount, 1)
+        XCTAssertEqual(preview.logsToImport, 0)
+        XCTAssertEqual(preview.dayContextRowsToApply, 1)
+    }
+
     func testRepeatedImportDoesNotDuplicateLogs() throws {
         let source = Plan(name: "Repeatable", kind: nil, startDate: Date())
         let day = PlanDay(date: source.startDate)

--- a/ClimbingProgramTests/PlanCSVExchangeTests.swift
+++ b/ClimbingProgramTests/PlanCSVExchangeTests.swift
@@ -47,6 +47,16 @@ final class PlanCSVExchangeTests: XCTestCase {
         XCTAssertEqual(parsed.exercises.first?.name, "Imported Drill")
     }
 
+    func testPlanExportFilenameUsesSanitizedPlanNameAndDate() {
+        let plan = Plan(name: "My Plan / Strength", kind: nil, startDate: Date())
+        let filename = PlanCSVExchange.exportFilename(
+            for: plan,
+            exportedAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+
+        XCTAssertNotNil(filename.range(of: #"^klettrack_My_Plan_Strength_\d{4}-\d{2}-\d{2}$"#, options: .regularExpression))
+    }
+
     func testImportNewPlanBackfillsMissingExerciseUnderImportedCatalog() throws {
         let source = Plan(name: "Imported Plan", kind: nil, startDate: Date())
         let day = PlanDay(date: source.startDate)

--- a/ClimbingProgramTests/PlanCSVExchangeTests.swift
+++ b/ClimbingProgramTests/PlanCSVExchangeTests.swift
@@ -47,6 +47,17 @@ final class PlanCSVExchangeTests: XCTestCase {
         XCTAssertEqual(parsed.exercises.first?.name, "Imported Drill")
     }
 
+    func testParseAcceptsUTF8ByteOrderMarkBeforeHeader() throws {
+        let plan = Plan(name: "BOM Plan", kind: nil, startDate: Date())
+        context.insert(plan)
+        try context.save()
+
+        let csv = "\u{FEFF}" + PlanCSVExchange.export(plan: plan, in: context).csv
+        let parsed = try PlanCSVExchange.parse(csv)
+
+        XCTAssertEqual(parsed.plan.name, "BOM Plan")
+    }
+
     func testPlanExportFilenameUsesSanitizedPlanNameAndDate() {
         let plan = Plan(name: "My Plan / Strength", kind: nil, startDate: Date())
         let filename = PlanCSVExchange.exportFilename(

--- a/ClimbingProgramTests/PlanCSVExchangeTests.swift
+++ b/ClimbingProgramTests/PlanCSVExchangeTests.swift
@@ -133,6 +133,70 @@ final class PlanCSVExchangeTests: XCTestCase {
         XCTAssertEqual(plan.name, "Edited Existing")
     }
 
+    func testExistingImportAppliesScheduleMetadataAroundProtectedRecords() throws {
+        let plan = Plan(name: "Existing", kind: nil, startDate: Date())
+        let day = PlanDay(date: plan.startDate)
+        day.chosenExercises = ["Logged Exercise", "Remove Me"]
+        plan.days = [day]
+        context.insert(plan)
+
+        let session = Session(date: plan.startDate)
+        let loggedItem = SessionItem(
+            exerciseName: "Logged Exercise",
+            planSourceId: plan.id,
+            planName: plan.name,
+            planDayId: day.id,
+            reps: 5,
+            notes: "Original"
+        )
+        session.items = [loggedItem]
+        context.insert(session)
+        try context.save()
+
+        var edited = try PlanCSVExchange.parse(PlanCSVExchange.export(plan: plan, in: context).csv)
+        let loggedID = try XCTUnwrap(edited.exercises.first { $0.name == "Logged Exercise" }?.id)
+        let newID = UUID()
+        edited.exercises.append(.init(id: newID, catalogID: nil, name: "New Exercise", area: nil, description: nil, reps: nil, sets: nil, duration: nil, rest: nil, notes: nil))
+        edited.days[0].dayTypeKey = "updated"
+        edited.days[0].dayTypeName = "Updated"
+        edited.days[0].dayTypeColor = "purple"
+        edited.days[0].dailyNotes = "Updated notes"
+        edited.days[0].exerciseRefs = [(newID, 0), (loggedID, 1)]
+
+        _ = try PlanCSVExchange.apply(edited, mode: .existing(plan), in: context)
+
+        XCTAssertEqual(day.type?.key, "updated")
+        XCTAssertEqual(day.dailyNotes, "Updated notes")
+        XCTAssertEqual(day.chosenExercises, ["New Exercise", "Logged Exercise"])
+        XCTAssertEqual(day.exerciseOrder["New Exercise"], 0)
+        XCTAssertEqual(day.exerciseOrder["Logged Exercise"], 1)
+        XCTAssertEqual(loggedItem.reps, 5)
+        XCTAssertEqual(loggedItem.notes, "Original")
+    }
+
+    func testExistingImportCanOverwriteDayContextByExplicitChoice() throws {
+        let plan = Plan(name: "Context Plan", kind: nil, startDate: Date())
+        plan.days = [PlanDay(date: plan.startDate)]
+        context.insert(plan)
+        let dayLog = try XCTUnwrap(DayLogStore.dayLog(for: plan.startDate, in: context))
+        DayLogStore.setNote("Original context", for: dayLog)
+        let originalTag = try XCTUnwrap(DayLogStore.createTag(name: "Original", colorKey: "red", in: context))
+        DayLogStore.setTag(originalTag, assigned: true, to: dayLog)
+        try context.save()
+
+        var edited = try PlanCSVExchange.parse(PlanCSVExchange.export(plan: plan, in: context).csv)
+        edited.contexts[0].note = "CSV context"
+        edited.contexts[0].tags = [.init(name: "CSV", colorKey: "blue")]
+
+        _ = try PlanCSVExchange.apply(edited, mode: .existing(plan), in: context)
+        XCTAssertEqual(dayLog.note, "Original context")
+        XCTAssertEqual(DayLogStore.activeTags(from: dayLog).map(\.name), ["Original"])
+
+        _ = try PlanCSVExchange.apply(edited, mode: .existing(plan), overwriteDayContext: true, in: context)
+        XCTAssertEqual(dayLog.note, "CSV context")
+        XCTAssertEqual(DayLogStore.activeTags(from: dayLog).map(\.name), ["CSV"])
+    }
+
     func testRepeatedImportDoesNotDuplicateLogs() throws {
         let source = Plan(name: "Repeatable", kind: nil, startDate: Date())
         let day = PlanDay(date: source.startDate)

--- a/ClimbingProgramTests/PlanCSVExchangeTests.swift
+++ b/ClimbingProgramTests/PlanCSVExchangeTests.swift
@@ -69,7 +69,7 @@ final class PlanCSVExchangeTests: XCTestCase {
         let parsed = try PlanCSVExchange.parse(csv)
 
         XCTAssertNotEqual(parsed.plan.id, source.id)
-        XCTAssertTrue(parsed.warnings.contains { $0.localizedStandardContains("new ID") })
+        XCTAssertTrue(parsed.warnings.isEmpty)
 
         _ = try PlanCSVExchange.apply(parsed, mode: .newPlan, in: context)
         let plans = try context.fetch(FetchDescriptor<Plan>())

--- a/ClimbingProgramTests/PlanCSVExchangeTests.swift
+++ b/ClimbingProgramTests/PlanCSVExchangeTests.swift
@@ -225,7 +225,7 @@ final class PlanCSVExchangeTests: XCTestCase {
 
         let preview = PlanCSVExchange.preview(edited, mode: .existing(plan), overwriteDayContext: true, in: context)
 
-        XCTAssertEqual(preview.metadataChanges, ["Plan name"])
+        XCTAssertEqual(preview.metadataChanges, ["Plan name", "Start date"])
         XCTAssertEqual(preview.daysToUpdate, 1)
         XCTAssertEqual(preview.scheduleEntriesToAdd, 1)
         XCTAssertEqual(preview.scheduleEntriesToRemove, 1)

--- a/ClimbingProgramTests/PlanCSVExchangeTests.swift
+++ b/ClimbingProgramTests/PlanCSVExchangeTests.swift
@@ -59,6 +59,23 @@ final class PlanCSVExchangeTests: XCTestCase {
         XCTAssertEqual(parsed.plan.name, "BOM Plan")
     }
 
+    func testImportGeneratesPlanIDWhenPlanIDIsMissing() throws {
+        let source = Plan(name: "External Plan", kind: nil, startDate: Date())
+        context.insert(source)
+        try context.save()
+
+        let csv = PlanCSVExchange.export(plan: source, in: context).csv
+            .replacingOccurrences(of: "plan,\(source.id.uuidString),", with: "plan,,")
+        let parsed = try PlanCSVExchange.parse(csv)
+
+        XCTAssertNotEqual(parsed.plan.id, source.id)
+        XCTAssertTrue(parsed.warnings.contains { $0.localizedStandardContains("new ID") })
+
+        _ = try PlanCSVExchange.apply(parsed, mode: .newPlan, in: context)
+        let plans = try context.fetch(FetchDescriptor<Plan>())
+        XCTAssertTrue(plans.contains { $0.id == parsed.plan.id && $0.name == "External Plan" })
+    }
+
     func testPlanExportFilenameUsesSanitizedPlanNameAndDate() {
         let plan = Plan(name: "My Plan / Strength", kind: nil, startDate: Date())
         let filename = PlanCSVExchange.exportFilename(

--- a/ClimbingProgramTests/TestSupport.swift
+++ b/ClimbingProgramTests/TestSupport.swift
@@ -13,7 +13,7 @@ class BaseSwiftDataTestCase: XCTestCase {
             Activity.self, TrainingType.self, Exercise.self, BoulderCombination.self,
             Session.self, SessionItem.self,
             DayLog.self, DayTag.self,
-            Plan.self, PlanDay.self,
+            Plan.self, PlanDay.self, PlanKindModel.self, DayTypeModel.self, PlanExerciseDefinition.self,
             TimerTemplate.self, TimerInterval.self, TimerSession.self, TimerLap.self,
             ClimbEntry.self, ClimbStyle.self, ClimbGym.self, ClimbMedia.self,
             TB2ClimbMetadata.self, TB2ClimbStatsMetadata.self


### PR DESCRIPTION
## Summary
- Add plan CSV import/export with existing-plan merge protection and new-plan creation.
- Backfill missing exercises under Imported → Imported Plans.
- Add catalog exercise reassignment, bulk movement, safe node deletion, and Imported cleanup.
- Preserve plan-local data, logs, climbs, and shared exercise identities.
- Replace the Plans screen top-level action menu with a + menu for New Plan and Import Plan.
- Keep plan-specific plan export/import actions while removing duplicate log export, share, and import actions from the Plans screen.
- Debounce daily-context autosave to improve typing responsiveness.
- Preserve daily note whitespace exactly as entered instead of trimming it during save.

## Verification
- iOS 17 Swift source type-check passes.
- XCTest source parsing passes.
- DayLogStore tests cover preservation of leading/trailing whitespace and empty-note handling.
- Full XCTest execution is blocked in the current environment because no simulator runtime is available.