### PR TITLE
Active Plan Auto selection module

### DIFF
--- a/ClimbingProgram/app/RootTabView.swift
+++ b/ClimbingProgram/app/RootTabView.swift
@@ -57,6 +57,10 @@ struct PlanDayNavigationItem: Hashable {
     }
 }
 
+struct ActivePlanSelectionNavigationItem: Hashable {
+    let currentPlanID: UUID?
+}
+
 struct RootTabView: View {
     private enum SheetRoute: String, Identifiable {
         case settings

--- a/ClimbingProgram/features/plans/ActivePlanSelection.swift
+++ b/ClimbingProgram/features/plans/ActivePlanSelection.swift
@@ -1,0 +1,170 @@
+//
+//  ActivePlanSelection.swift
+//  Klettrack
+//
+
+import SwiftUI
+import SwiftData
+
+enum ActivePlanPreference {
+    static let userDefaultsKey = "klettrack.activePlanID"
+    static let optedOutKey = "klettrack.activePlanOptedOut"
+
+    static func planID(from defaults: UserDefaults = .standard) -> UUID? {
+        guard let rawValue = defaults.string(forKey: userDefaultsKey) else { return nil }
+        return UUID(uuidString: rawValue)
+    }
+
+    static func save(planID: UUID, to defaults: UserDefaults = .standard) {
+        defaults.set(planID.uuidString, forKey: userDefaultsKey)
+        defaults.set(false, forKey: optedOutKey)
+    }
+
+    static func clear(from defaults: UserDefaults = .standard) {
+        defaults.removeObject(forKey: userDefaultsKey)
+    }
+
+    static func isOptedOut(from defaults: UserDefaults = .standard) -> Bool {
+        defaults.bool(forKey: optedOutKey)
+    }
+
+    static func setOptedOut(_ optedOut: Bool, in defaults: UserDefaults = .standard) {
+        defaults.set(optedOut, forKey: optedOutKey)
+    }
+}
+
+struct ActivePlanResolver {
+    enum Resolution: Equatable {
+        case active(UUID)
+        case choose
+        case none
+    }
+
+    static func resolve(
+        plans: [Plan],
+        storedPlanID: UUID?,
+        isOptedOut: Bool = false,
+        today: Date = .now,
+        calendar: Calendar = .current
+    ) -> Resolution {
+        if isOptedOut {
+            return .none
+        }
+
+        if let storedPlanID, plans.contains(where: { $0.id == storedPlanID }) {
+            return .active(storedPlanID)
+        }
+
+        let matchingPlanIDs = plans
+            .filter { plan in
+                plan.days.contains { calendar.isDate($0.date, inSameDayAs: today) }
+            }
+            .map(\.id)
+
+        switch matchingPlanIDs.count {
+        case 0:
+            return .none
+        case 1:
+            return .active(matchingPlanIDs[0])
+        default:
+            return .choose
+        }
+    }
+}
+
+struct ActivePlanSelectionView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Query(sort: [SortDescriptor<Plan>(\.startDate, order: .reverse)]) private var plans: [Plan]
+
+    let initialSelectionID: UUID?
+    let onSelectionComplete: (UUID?) -> Void
+
+    @State private var selectedPlanID: UUID?
+    @State private var showingNotInterestedConfirmation = false
+
+    init(
+        initialSelectionID: UUID? = nil,
+        onSelectionComplete: @escaping (UUID?) -> Void
+    ) {
+        self.initialSelectionID = initialSelectionID
+        self.onSelectionComplete = onSelectionComplete
+        _selectedPlanID = State(initialValue: initialSelectionID)
+    }
+
+    var body: some View {
+        List {
+            if plans.isEmpty {
+                ContentUnavailableView(
+                    "No Plans",
+                    systemImage: "calendar.badge.plus",
+                    description: Text("Create a plan before selecting an active plan.")
+                )
+            } else {
+                Section {
+                    ForEach(plans) { plan in
+                        Button {
+                            selectedPlanID = plan.id
+                        } label: {
+                            HStack(spacing: 12) {
+                                PlanRow(plan: plan, isActive: selectedPlanID == plan.id)
+                                Spacer()
+                                if selectedPlanID == plan.id {
+                                    Image(systemName: "checkmark.circle.fill")
+                                        .foregroundStyle(.green)
+                                        .accessibilityLabel("Selected active plan")
+                                }
+                            }
+                        }
+                        .buttonStyle(.plain)
+                    }
+                } header: {
+                    Text("Choose your current active plan")
+                }
+
+                Section {
+                    HStack {
+                        Spacer()
+                        Button("Not interested") {
+                            showingNotInterestedConfirmation = true
+                        }
+                        .foregroundStyle(.blue.opacity(0.8))
+                        Spacer()
+                    }
+                } footer: {
+                    Text("You can set a plan as active at any time using the ")
+                    + Text(Image(systemName: "bolt.badge.clock.fill"))
+                    + Text(" button.")
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .toolbar {
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Done") {
+                    guard let selectedPlanID else { return }
+                    ActivePlanPreference.save(planID: selectedPlanID)
+                    onSelectionComplete(selectedPlanID)
+                    dismiss()
+                }
+                .disabled(selectedPlanID == nil)
+            }
+        }
+        .task {
+            guard selectedPlanID == nil,
+                  let storedPlanID = ActivePlanPreference.planID(),
+                  plans.contains(where: { $0.id == storedPlanID }) else { return }
+            selectedPlanID = storedPlanID
+        }
+        .alert("Continue without an active plan?", isPresented: $showingNotInterestedConfirmation) {
+            Button("Understood", role: .destructive) {
+                ActivePlanPreference.clear()
+                ActivePlanPreference.setOptedOut(true)
+                onSelectionComplete(nil)
+                dismiss()
+            }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text("Your plans will continue to work as before. The Plans module will now show all your plans instead of opening the active plan by default")
+        }
+    }
+}

--- a/ClimbingProgram/features/plans/PlansViews.swift
+++ b/ClimbingProgram/features/plans/PlansViews.swift
@@ -119,6 +119,11 @@ struct PlansListView: View {
     @Query(sort: [SortDescriptor<Plan>(\Plan.startDate, order: .reverse)]) private var plans: [Plan]
 
     @State private var sheetRoute: SheetRoute?
+    @State private var activePlanID: UUID?
+    @State private var requiresActivePlanSelection = false
+    @State private var showingAllPlans = false
+    @AppStorage(ActivePlanPreference.userDefaultsKey) private var activePlanIDRawValue = ""
+    @AppStorage(ActivePlanPreference.optedOutKey) private var activePlanOptedOut = false
 
     // Plan export / import state
     @State private var showPlanExporter = false
@@ -144,29 +149,23 @@ struct PlansListView: View {
                 timerAppState.plansNavigationPath = newPath
             }
         )) {
-            plansList
-                .listStyle(.insetGrouped)
-                .navigationTitle("TRAIN")
-                .navigationBarTitleDisplayMode(.large)
+            mainContent
+                .task(id: planIDs) {
+                    resolveActivePlan()
+                }
+                .onChange(of: isDataReady) { _, _ in
+                    resolveActivePlan()
+                }
+                .onChange(of: activePlanIDRawValue) { _, _ in
+                    resolveActivePlan()
+                }
+                .onChange(of: activePlanOptedOut) { _, _ in
+                    resolveActivePlan()
+                }
                 .plansDestinations(
                     plans: plans,
                     timerAppState: timerAppState,
                     focusedDayContextField: $focusedDayContextField
-                )
-                .plansToolbar(
-                    isDataReady: isDataReady,
-                    showingNew: Binding(
-                        get: { sheetRoute == .newPlan },
-                        set: { newValue in
-                            if newValue {
-                                sheetRoute = .newPlan
-                            } else if sheetRoute == .newPlan {
-                                sheetRoute = nil
-                            }
-                        }
-                    ),
-                    showPlanImporter: $showPlanImporter,
-                    planImportTarget: $planImportTarget
                 )
                 .sheet(item: $sheetRoute) { route in
                     switch route {
@@ -216,6 +215,74 @@ struct PlansListView: View {
         }
     }
 
+    @ViewBuilder
+    private var mainContent: some View {
+        if requiresActivePlanSelection {
+            ActivePlanSelectionView { selectedPlanID in
+                if let selectedPlanID {
+                    setActivePlan(selectedPlanID)
+                } else {
+                    setNoActivePlan()
+                }
+            }
+        } else if showingAllPlans {
+            plansList
+                .listStyle(.insetGrouped)
+        } else if let activePlan = plans.first(where: { $0.id == activePlanID }) {
+            PlanDetailView(
+                plan: activePlan,
+                focusedDayContextField: $focusedDayContextField,
+                onPlansTapped: showAllPlans
+            )
+        } else {
+            plansList
+                .listStyle(.insetGrouped)
+        }
+    }
+
+    private var planIDs: [UUID] {
+        plans.map(\.id)
+    }
+
+    private func resolveActivePlan() {
+        guard isDataReady else { return }
+
+        switch ActivePlanResolver.resolve(
+            plans: plans,
+            storedPlanID: UUID(uuidString: activePlanIDRawValue),
+            isOptedOut: activePlanOptedOut
+        ) {
+        case .active(let planID):
+            activePlanID = planID
+            requiresActivePlanSelection = false
+            ActivePlanPreference.save(planID: planID)
+        case .choose:
+            activePlanID = nil
+            requiresActivePlanSelection = true
+        case .none:
+            activePlanID = nil
+            requiresActivePlanSelection = false
+        }
+    }
+
+    private func setActivePlan(_ planID: UUID) {
+        activePlanID = planID
+        requiresActivePlanSelection = false
+        showingAllPlans = false
+        ActivePlanPreference.save(planID: planID)
+    }
+
+    private func setNoActivePlan() {
+        activePlanID = nil
+        requiresActivePlanSelection = false
+        showingAllPlans = true
+    }
+
+    private func showAllPlans() {
+        timerAppState.plansNavigationPath = NavigationPath()
+        showingAllPlans = true
+    }
+
     private var plansList: some View {
         List {
             ForEach(plans) { plan in
@@ -223,7 +290,7 @@ struct PlansListView: View {
                     Button {
                         timerAppState.plansNavigationPath.append(PlanNavigationItem(plan: plan))
                     } label: {
-                        PlanRow(plan: plan)
+                        PlanRow(plan: plan, isActive: activePlanID == plan.id)
                             .frame(maxWidth: .infinity, alignment: .leading)
                     }
                     .buttonStyle(.plain)
@@ -271,6 +338,30 @@ struct PlansListView: View {
                 try? context.save()
             }
         }
+        .navigationTitle("TRAIN")
+        .navigationBarTitleDisplayMode(.large)
+        .plansToolbar(
+            isDataReady: isDataReady,
+            onChangeActivePlan: changeActivePlan,
+            showingNew: Binding(
+                get: { sheetRoute == .newPlan },
+                set: { newValue in
+                    if newValue {
+                        sheetRoute = .newPlan
+                    } else if sheetRoute == .newPlan {
+                        sheetRoute = nil
+                    }
+                }
+            ),
+            showPlanImporter: $showPlanImporter,
+            planImportTarget: $planImportTarget
+        )
+    }
+
+    private func changeActivePlan() {
+        timerAppState.plansNavigationPath.append(
+            ActivePlanSelectionNavigationItem(currentPlanID: activePlanID)
+        )
     }
 
     
@@ -336,6 +427,11 @@ private struct PlansDestinationsModifier: ViewModifier {
                     Text("Plan day not found")
                 }
             }
+            .navigationDestination(for: ActivePlanSelectionNavigationItem.self) { item in
+                ActivePlanSelectionView(initialSelectionID: item.currentPlanID) { _ in
+                    timerAppState.plansNavigationPath = NavigationPath()
+                }
+            }
     }
 }
 
@@ -355,6 +451,7 @@ private extension View {
 
 private struct PlansToolbarModifier: ViewModifier {
     let isDataReady: Bool
+    let onChangeActivePlan: () -> Void
 
     @Binding var showingNew: Bool
     @Binding var showPlanImporter: Bool
@@ -362,6 +459,17 @@ private struct PlansToolbarModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content.toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    guard isDataReady else { return }
+                    onChangeActivePlan()
+                } label: {
+                    Image(systemName: "bolt.badge.clock.fill")
+                        .accessibilityLabel("Change active plan")
+                }
+                .disabled(!isDataReady)
+            }
+
             ToolbarItem(placement: .topBarTrailing) {
                 Menu {
                     Button {
@@ -391,12 +499,14 @@ private struct PlansToolbarModifier: ViewModifier {
 private extension View {
     func plansToolbar(
         isDataReady: Bool,
+        onChangeActivePlan: @escaping () -> Void,
         showingNew: Binding<Bool>,
         showPlanImporter: Binding<Bool>,
         planImportTarget: Binding<Plan?>
     ) -> some View {
         modifier(PlansToolbarModifier(
             isDataReady: isDataReady,
+            onChangeActivePlan: onChangeActivePlan,
             showingNew: showingNew,
             showPlanImporter: showPlanImporter,
             planImportTarget: planImportTarget
@@ -411,15 +521,28 @@ struct EditablePlanDayNav: Hashable {
 }
 
 // Small, explicit row view reduces type inference work
-private struct PlanRow: View {
+struct PlanRow: View {
     let plan: Plan
+    let isActive: Bool
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(plan.name)
-                .font(.headline)
-                .lineLimit(1)
-                .truncationMode(.tail)
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+                Text(plan.name)
+                    .font(.headline)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+
+                if isActive {
+                    Text("ACTIVE")
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 3)
+                        .background(.green, in: Capsule())
+                        .accessibilityLabel("Active plan")
+                }
+            }
             Text(subtitle)
                 .font(.footnote)
                 .foregroundStyle(.secondary)
@@ -535,13 +658,16 @@ struct PlanDetailView: View {
     @Environment(TimerAppState.self) private var timerAppState
     @State private var plan: Plan
     let focusedDayContextField: FocusState<DayContextFocusedField?>.Binding
+    let onPlansTapped: (() -> Void)?
 
     init(
         plan: Plan,
-        focusedDayContextField: FocusState<DayContextFocusedField?>.Binding
+        focusedDayContextField: FocusState<DayContextFocusedField?>.Binding,
+        onPlansTapped: (() -> Void)? = nil
     ) {
         _plan = State(initialValue: plan)
         self.focusedDayContextField = focusedDayContextField
+        self.onPlansTapped = onPlansTapped
     }
 
     private enum ViewMode: Int {
@@ -644,14 +770,25 @@ struct PlanDetailView: View {
     // Break down toolbar into smaller components
     @ToolbarContentBuilder
     private var toolbarContent: some ToolbarContent {
-            ToolbarItem(placement: .topBarTrailing) {
-                Menu {
-                    Button("Add more week") {
-                        weeksToAdd = ""
-                        showingDupPrompt = true
+            ToolbarItem(placement: .topBarLeading) {
+                Button {
+                    if let onPlansTapped {
+                        onPlansTapped()
+                    } else if !timerAppState.plansNavigationPath.isEmpty {
+                        timerAppState.plansNavigationPath.removeLast()
                     }
                 } label: {
-                    Label("Duplicate weeks", systemImage: "plus.square.on.square")
+                    Label("Plans", systemImage: "chevron.backward")
+                }
+                .accessibilityLabel("Back to Plans")
+            }
+
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    weeksToAdd = ""
+                    showingDupPrompt = true
+                } label: {
+                    Label("Add more weeks", systemImage: "plus")
                 }
             }
     }
@@ -755,6 +892,7 @@ struct PlanDetailView: View {
         // plan overview destination.
         .ignoresSafeArea(.keyboard, edges: .bottom)
         .navigationTitle(plan.name)
+        .navigationBarBackButtonHidden(true)
         .navigationDestination(for: EditablePlanDayNav.self) { nav in
             if nav.planId == plan.id,
                let idx = plan.days.firstIndex(where: { $0.id == nav.planDayId }) {
@@ -1869,8 +2007,6 @@ private struct PlanClimbLogView: View {
         )
         climbEntry.planSourceId = p?.id
         climbEntry.planDayId = planDay.id
-
-        let attemptsDouble = climbEntry.attempts != nil ? Double(climbEntry.attempts!) : nil
 
         session.items.append(SessionItem(
             exerciseName: exerciseName,

--- a/ClimbingProgramTests/ActivePlanResolverTests.swift
+++ b/ClimbingProgramTests/ActivePlanResolverTests.swift
@@ -1,0 +1,128 @@
+import XCTest
+@testable import klettrack
+
+final class ActivePlanResolverTests: XCTestCase {
+    private var calendar: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0) ?? .gmt
+        return calendar
+    }
+
+    private func plan(
+        id: UUID = UUID(),
+        days: [Date]
+    ) -> Plan {
+        let plan = Plan(id: id, name: "Plan", kind: nil, startDate: days[0])
+        plan.days = days.map { PlanDay(date: $0) }
+        return plan
+    }
+
+    func testExactlyOnePlanContainingTodayIsSelected() {
+        let today = calendar.startOfDay(for: Date(timeIntervalSince1970: 1_750_000_000))
+        let matching = plan(days: [today])
+        let other = plan(days: [today.addingTimeInterval(86_400)])
+
+        let result = ActivePlanResolver.resolve(
+            plans: [matching, other],
+            storedPlanID: nil,
+            today: today,
+            calendar: calendar
+        )
+
+        XCTAssertEqual(result, .active(matching.id))
+    }
+
+    func testMultiplePlansContainingTodayRequireSelectionFromAllPlans() {
+        let today = calendar.startOfDay(for: Date(timeIntervalSince1970: 1_750_000_000))
+        let first = plan(days: [today])
+        let second = plan(days: [today])
+        let future = plan(days: [today.addingTimeInterval(86_400)])
+
+        let result = ActivePlanResolver.resolve(
+            plans: [first, second, future],
+            storedPlanID: nil,
+            today: today,
+            calendar: calendar
+        )
+
+        XCTAssertEqual(result, .choose)
+        XCTAssertEqual(Set([first.id, second.id, future.id]).count, 3)
+    }
+
+    func testNoPlanContainingTodayFallsBackToNone() {
+        let today = calendar.startOfDay(for: Date(timeIntervalSince1970: 1_750_000_000))
+        let plan = plan(days: [today.addingTimeInterval(86_400)])
+
+        let result = ActivePlanResolver.resolve(
+            plans: [plan],
+            storedPlanID: nil,
+            today: today,
+            calendar: calendar
+        )
+
+        XCTAssertEqual(result, .none)
+    }
+
+    func testOptedOutStatePreventsAutomaticSelection() {
+        let today = calendar.startOfDay(for: Date(timeIntervalSince1970: 1_750_000_000))
+        let matching = plan(days: [today])
+
+        let result = ActivePlanResolver.resolve(
+            plans: [matching],
+            storedPlanID: nil,
+            isOptedOut: true,
+            today: today,
+            calendar: calendar
+        )
+
+        XCTAssertEqual(result, .none)
+    }
+
+    func testValidPersistedSelectionOverridesDateMatching() {
+        let today = calendar.startOfDay(for: Date(timeIntervalSince1970: 1_750_000_000))
+        let automatic = plan(days: [today])
+        let persisted = plan(days: [today.addingTimeInterval(86_400)])
+
+        let result = ActivePlanResolver.resolve(
+            plans: [automatic, persisted],
+            storedPlanID: persisted.id,
+            today: today,
+            calendar: calendar
+        )
+
+        XCTAssertEqual(result, .active(persisted.id))
+    }
+
+    func testDeletedPersistedSelectionIsReResolved() {
+        let today = calendar.startOfDay(for: Date(timeIntervalSince1970: 1_750_000_000))
+        let replacement = plan(days: [today])
+
+        let result = ActivePlanResolver.resolve(
+            plans: [replacement],
+            storedPlanID: UUID(),
+            today: today,
+            calendar: calendar
+        )
+
+        XCTAssertEqual(result, .active(replacement.id))
+    }
+
+    func testActivePlanPreferencePersistsAndClearsSelection() {
+        let suiteName = "ActivePlanResolverTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        let id = UUID()
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        ActivePlanPreference.save(planID: id, to: defaults)
+        XCTAssertEqual(ActivePlanPreference.planID(from: defaults), id)
+
+        ActivePlanPreference.setOptedOut(true, in: defaults)
+        ActivePlanPreference.save(planID: id, to: defaults)
+        XCTAssertFalse(ActivePlanPreference.isOptedOut(from: defaults))
+
+        ActivePlanPreference.clear(from: defaults)
+        XCTAssertNil(ActivePlanPreference.planID(from: defaults))
+    }
+}


### PR DESCRIPTION
## Summary

- Open the Plans tab directly on the persisted active plan.
- Automatically resolve the active plan based on today’s plan days.
- Prompt for a selection when multiple plans match today.
- Add persistent manual active-plan selection.
- Add the `bolt.badge.clock.fill` button for changing the active plan.
- Add a green uppercase `ACTIVE` badge to plan rows.
- Allow users to opt out and continue viewing all plans.
- Add a clear `Plans` back navigation button from plan detail.
- Keep plan creation, import, and plan-day navigation behavior intact.

## Testing

- Added resolver tests covering:
  - Single matching plan
  - Multiple matching plans
  - No matching plan
  - Persisted selection
  - Deleted selection
  - Opt-out behavior
  - UserDefaults persistence
- Verified formatting with `git diff --check`.